### PR TITLE
Put icon into language selector

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -624,26 +624,6 @@ async function generateBatchQRCodes(format: 'png' | 'svg') {
                 </svg>
               </span>
             </button>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              class="icon"
-              width="36"
-              height="36"
-              viewBox="0 0 24 24"
-            >
-              <g
-                fill="none"
-                stroke="#abcbca"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              >
-                <path d="M4 5h7M7 4c0 4.846 0 7 .5 8" />
-                <path
-                  d="M10 8.5c0 2.286-2 4.5-3.5 4.5S4 11.865 4 11c0-2 1-3 3-3s5 .57 5 2.857c0 1.524-.667 2.571-2 3.143m2 6l4-9l4 9m-.9-2h-6.2"
-                />
-              </g>
-            </svg>
             <Combobox
               :items="locales"
               v-model:value="locale"

--- a/src/App.vue
+++ b/src/App.vue
@@ -629,7 +629,30 @@ async function generateBatchQRCodes(format: 'png' | 'svg') {
               v-model:value="locale"
               v-model:open="isLocaleSelectOpen"
               :button-label="t('Select language')"
-            />
+            >
+              <template #button-icon>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  class="icon -ml-1.5 size-6 shrink-0"
+                  width="36"
+                  height="36"
+                  viewBox="0 0 24 24"
+                >
+                  <g
+                    fill="none"
+                    stroke="#abcbca"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                  >
+                    <path d="M4 5h7M7 4c0 4.846 0 7 .5 8" />
+                    <path
+                      d="M10 8.5c0 2.286-2 4.5-3.5 4.5S4 11.865 4 11c0-2 1-3 3-3s5 .57 5 2.857c0 1.524-.667 2.571-2 3.143m2 6l4-9l4 9m-.9-2h-6.2"
+                    />
+                  </g>
+                </svg>
+              </template>
+            </Combobox>
           </div>
         </div>
       </div>

--- a/src/components/ui/Combobox/Combobox.vue
+++ b/src/components/ui/Combobox/Combobox.vue
@@ -33,27 +33,7 @@ defineProps<{
         :aria-label="buttonLabel"
         class="w-fit flex gap-2 items-center justify-between focus-visible:ring-1 bg-zinc-50 dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 dark:hover:bg-zinc-900 dark:hover:text-zinc-100"
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          class="icon -ml-1.5 size-6 shrink-0"
-          width="36"
-          height="36"
-          viewBox="0 0 24 24"
-        >
-          <g
-            fill="none"
-            stroke="#abcbca"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          >
-            <path d="M4 5h7M7 4c0 4.846 0 7 .5 8" />
-            <path
-              d="M10 8.5c0 2.286-2 4.5-3.5 4.5S4 11.865 4 11c0-2 1-3 3-3s5 .57 5 2.857c0 1.524-.667 2.571-2 3.143m2 6l4-9l4 9m-.9-2h-6.2"
-            />
-          </g>
-        </svg>
-
+        <slot name="button-icon"></slot>
         {{ value ? items.find((item) => item.value === value)?.label : 'Select item...' }}
         <ChevronsUpDown class="size-4 shrink-0 opacity-50" />
       </Button>

--- a/src/components/ui/Combobox/Combobox.vue
+++ b/src/components/ui/Combobox/Combobox.vue
@@ -31,10 +31,31 @@ defineProps<{
         role="combobox"
         :aria-expanded="open"
         :aria-label="buttonLabel"
-        class="w-fit justify-between focus-visible:ring-1 bg-zinc-50 dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 dark:hover:bg-zinc-900 dark:hover:text-zinc-100"
+        class="w-fit flex gap-2 items-center justify-between focus-visible:ring-1 bg-zinc-50 dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 dark:hover:bg-zinc-900 dark:hover:text-zinc-100"
       >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="icon -ml-1.5 size-6 shrink-0"
+          width="36"
+          height="36"
+          viewBox="0 0 24 24"
+        >
+          <g
+            fill="none"
+            stroke="#abcbca"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          >
+            <path d="M4 5h7M7 4c0 4.846 0 7 .5 8" />
+            <path
+              d="M10 8.5c0 2.286-2 4.5-3.5 4.5S4 11.865 4 11c0-2 1-3 3-3s5 .57 5 2.857c0 1.524-.667 2.571-2 3.143m2 6l4-9l4 9m-.9-2h-6.2"
+            />
+          </g>
+        </svg>
+
         {{ value ? items.find((item) => item.value === value)?.label : 'Select item...' }}
-        <ChevronsUpDown class="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        <ChevronsUpDown class="size-4 shrink-0 opacity-50" />
       </Button>
     </PopoverTrigger>
     <PopoverContent class="w-fit p-0">


### PR DESCRIPTION
Here's what I did:

- Moved the translation icon into *Combobox.vue*
- Resized the icon to `size-6`
- Updated the combobox button display to flex with `items-center`
- Changed the combobox button spacing from margin to gap
- Adjusted the position of the icon using negative margin
- Refactored `h-4 w-4` to [`size-4`](https://tailwindcss.com/docs/width#setting-both-width-and-height) 

Fixes #79 ✅