### PR TITLE
Add QR code frame feature with customizable text and styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ An app to create beautiful QR codes and scan various QR code types.
 
 - ✅ Accessible: minimally WCAG A compliant
 - 🎨 Customizable colors and styles
-- 🖼️ Export to SVG and PNG
+- 🖼️ Export to PNG, JPG, SVG
 - 📋 Copy to clipboard
 - 🌓 Light/dark/system-preference mode toggle
 - 🎲 Randomize style button
@@ -27,6 +27,7 @@ An app to create beautiful QR codes and scan various QR code types.
 - 💾 Save & Load QR Code config
 - 🖼️ Upload custom image for logo
 - 🎭 Presets: Pre-crafted QR code styles
+- 🖌️ Frame customization: Add text labels and style the frame around your QR code
 - 🛡️ Error correction level: affects the size of the QR code and logo within. Use lower correction levels for bigger pieces of data to ensure that it can be read.
 - 📱 QR Code Scanner: Scan QR codes using your camera or by uploading images, with intelligent detection for URLs, emails, phone numbers, WiFi credentials, and more
 - 📦 Batch data export: Import a CSV file with multiple data strings and export QR codes for them all at once.
@@ -38,11 +39,13 @@ An app to create beautiful QR codes and scan various QR code types.
 <summary>MiniQR can also be installed as a Progressive Web App (PWA) on your device</summary>
 
 1. **Desktop (Chrome/Edge)**:
+
    - Visit [mini-qr.vercel.app](https://mini-qr.vercel.app)
    - Click the install icon (➕) in the address bar
    - Click "Install" in the prompt
 
 2. **Mobile (Android)**:
+
    - Visit [mini-qr.vercel.app](https://mini-qr.vercel.app)
    - Tap the "Add to Home Screen" option in your browser menu
    - Tap "Install" or "Add"

--- a/src/App.vue
+++ b/src/App.vue
@@ -274,8 +274,8 @@ const isModeToggleDisabled = computed(() => {
       class="relative grid min-h-screen place-items-center items-start bg-white p-8 pt-16 dark:bg-zinc-900 md:px-6 md:pt-8"
     >
       <!-- Main content area with conditional rendering based on app mode -->
-      <div class="w-full md:w-5/6">
-        <div v-if="appMode === AppMode.Create" class="create-mode">
+      <div class="w-full lg:w-5/6">
+        <div v-if="appMode === AppMode.Create">
           <QRCodeCreate :initial-data="capturedData" />
         </div>
         <div v-else class="flex flex-col items-center justify-center py-8">

--- a/src/App.vue
+++ b/src/App.vue
@@ -85,15 +85,15 @@ const isModeToggleDisabled = computed(() => {
 
         <!-- Mode toggle button - only visible on desktop -->
         <div
-          class="ml-4 flex items-center rounded-lg border border-zinc-300 bg-zinc-100 p-1 dark:border-zinc-700 dark:bg-zinc-800"
+          class="ml-4 flex items-center gap-1 rounded-lg border border-zinc-300 bg-zinc-100 p-1 dark:border-zinc-700 dark:bg-zinc-800"
         >
           <button
-            class="flex items-center gap-1 rounded-md px-2 py-1 text-sm transition-colors md:gap-2 md:px-3 md:py-1.5 md:text-base"
-            :class="
+            :class="[
+              'flex items-center gap-1 rounded-md px-2 py-1 text-sm outline-none transition-colors focus-visible:ring-1 focus-visible:ring-zinc-700 dark:focus-visible:ring-zinc-200 md:gap-2 md:px-3 md:py-1.5 md:text-base',
               appMode === AppMode.Create
                 ? 'bg-white text-zinc-900 shadow dark:bg-zinc-700 dark:text-zinc-100'
                 : 'text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100'
-            "
+            ]"
             @click="setAppMode(AppMode.Create)"
             :disabled="isModeToggleDisabled"
             :aria-label="t('Switch to Create Mode')"
@@ -107,12 +107,12 @@ const isModeToggleDisabled = computed(() => {
             <span>{{ t('Create') }}</span>
           </button>
           <button
-            class="flex items-center gap-1 rounded-md px-2 py-1 text-sm transition-colors md:gap-2 md:px-3 md:py-1.5 md:text-base"
-            :class="
+            :class="[
+              'flex items-center gap-1 rounded-md px-2 py-1 text-sm outline-none transition-colors focus-visible:ring-1 focus-visible:ring-zinc-700 dark:focus-visible:ring-zinc-200 md:gap-2 md:px-3 md:py-1.5 md:text-base',
               appMode === AppMode.Scan
                 ? 'bg-white text-zinc-900 shadow dark:bg-zinc-700 dark:text-zinc-100'
                 : 'text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100'
-            "
+            ]"
             @click="setAppMode(AppMode.Scan)"
             :disabled="isModeToggleDisabled"
             :aria-label="t('Switch to Scan Mode')"
@@ -207,11 +207,11 @@ const isModeToggleDisabled = computed(() => {
     >
       <div class="flex justify-center">
         <div
-          class="relative flex items-center rounded-lg border border-zinc-300 bg-zinc-100 p-1 shadow-lg transition-all duration-300 dark:border-zinc-700 dark:bg-zinc-800 dark:shadow-slate-800"
+          class="relative flex items-center gap-1 rounded-lg border border-zinc-300 bg-zinc-100 p-1 shadow-lg transition-all duration-300 dark:border-zinc-700 dark:bg-zinc-800 dark:shadow-slate-800"
         >
           <button
-            class="flex items-center gap-1 rounded-md px-2 py-1 text-sm transition-colors"
             :class="[
+              'flex items-center gap-1 rounded-md px-2 py-1 text-sm outline-none transition-colors focus-visible:ring-1 focus-visible:ring-zinc-700 dark:focus-visible:ring-zinc-200',
               appMode === AppMode.Create
                 ? 'bg-white text-zinc-900 shadow dark:bg-zinc-700 dark:text-zinc-100'
                 : 'text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100',
@@ -235,8 +235,8 @@ const isModeToggleDisabled = computed(() => {
             <span>{{ t('Create') }}</span>
           </button>
           <button
-            class="flex items-center gap-1 rounded-md px-2 py-1 text-sm transition-colors"
             :class="[
+              'flex items-center gap-1 rounded-md px-2 py-1 text-sm outline-none transition-colors focus-visible:ring-1 focus-visible:ring-zinc-700 dark:focus-visible:ring-zinc-200',
               appMode === AppMode.Scan
                 ? 'bg-white text-zinc-900 shadow dark:bg-zinc-700 dark:text-zinc-100'
                 : 'text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100',

--- a/src/components/MobileMenu.vue
+++ b/src/components/MobileMenu.vue
@@ -60,7 +60,7 @@ onUnmounted(() => {
     <!-- Hamburger menu button -->
     <button
       ref="reference"
-      class="flex size-9 items-center justify-center rounded-md border border-zinc-300 bg-zinc-100 text-zinc-800 hover:bg-zinc-200 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200 dark:hover:bg-zinc-700"
+      class="flex size-9 items-center justify-center rounded-md border border-zinc-300 bg-zinc-100 text-zinc-800 outline-none hover:bg-zinc-200 focus-visible:ring-1 focus-visible:ring-zinc-700 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200 dark:hover:bg-zinc-700 dark:focus-visible:ring-zinc-200"
       @click="toggleMenu"
       :aria-label="t('Menu')"
       aria-haspopup="true"

--- a/src/components/QRCodeCreate.vue
+++ b/src/components/QRCodeCreate.vue
@@ -78,6 +78,7 @@ const lastBackground = ref(defaultPreset.style.background)
 const DEFAULT_FRAME_TEXT = 'Scan for more info'
 const frameText = ref(DEFAULT_FRAME_TEXT)
 const frameTextPosition = ref<'top' | 'bottom' | 'left' | 'right'>('bottom')
+const showFrame = ref(true)
 const frameStyle = ref({
   textColor: '#000000',
   backgroundColor: 'transparent',
@@ -90,6 +91,7 @@ const frameStyle = ref({
 function resetFrameTemplate() {
   frameText.value = DEFAULT_FRAME_TEXT
   frameTextPosition.value = 'bottom'
+  showFrame.value = true
   frameStyle.value = {
     textColor: '#000000',
     backgroundColor: 'transparent',
@@ -338,11 +340,13 @@ function createQrConfig() {
   return {
     props: qrCodeProps.value,
     style: style.value,
-    frame: {
-      text: frameText.value,
-      position: frameTextPosition.value,
-      style: frameStyle.value
-    }
+    frame: showFrame.value
+      ? {
+          text: frameText.value,
+          position: frameTextPosition.value,
+          style: frameStyle.value
+        }
+      : null
   }
 }
 
@@ -636,31 +640,69 @@ const mainContentContainer = ref<HTMLElement | null>(null)
         <div class="flex flex-col items-center">
           <!-- Handle indicator for bottom sheet -->
           <div class="mt-2 h-1 w-16 rounded-full bg-gray-300 dark:bg-gray-700"></div>
-          <div class="h-[150px] w-full overflow-hidden pt-2">
+          <div class="w-full p-4">
             <div class="grid place-items-center">
-              <div
-                class="grid place-items-center overflow-hidden"
-                :style="[
-                  style,
-                  {
-                    width: '120px',
-                    height: '120px',
-                    maxWidth: '100%',
-                    maxHeight: '100%'
-                  }
-                ]"
+              <QRCodeFrame
+                v-if="showFrame"
+                :frame-text="frameText"
+                :text-position="frameTextPosition"
+                :frame-style="frameStyle"
               >
-                <StyledQRCode
-                  v-bind="{
-                    ...qrCodeProps,
-                    data: data?.length > 0 ? data : t('Have nice day!'),
-                    width: 120,
-                    height: 120
-                  }"
-                  role="img"
-                  aria-label="QR code preview"
-                />
-              </div>
+                <template #qr-code>
+                  <div class="grid place-items-center">
+                    <div
+                      class="grid place-items-center overflow-hidden"
+                      :style="[
+                        style,
+                        {
+                          width: '120px',
+                          height: '120px',
+                          maxWidth: '100%',
+                          maxHeight: '100%'
+                        }
+                      ]"
+                    >
+                      <StyledQRCode
+                        v-bind="{
+                          ...qrCodeProps,
+                          data: data?.length > 0 ? data : t('Have nice day!'),
+                          width: 120,
+                          height: 120
+                        }"
+                        role="img"
+                        aria-label="QR code preview"
+                      />
+                    </div>
+                  </div>
+                </template>
+              </QRCodeFrame>
+              <template v-else>
+                <div class="grid place-items-center">
+                  <div
+                    class="grid place-items-center overflow-hidden"
+                    :style="[
+                      style,
+                      {
+                        width: '120px',
+                        height: '120px',
+                        maxWidth: '100%',
+                        maxHeight: '100%'
+                      }
+                    ]"
+                  >
+                    <StyledQRCode
+                      v-bind="{
+                        ...qrCodeProps,
+                        data: data?.length > 0 ? data : t('Have nice day!'),
+                        width: 120,
+                        height: 120
+                      }"
+                      role="img"
+                      aria-label="QR code preview"
+                    />
+                  </div>
+                </div>
+              </template>
             </div>
           </div>
           <div
@@ -699,6 +741,7 @@ const mainContentContainer = ref<HTMLElement | null>(null)
       <div id="main-content">
         <div ref="exportElementRef">
           <QRCodeFrame
+            v-if="showFrame"
             :frame-text="frameText"
             :text-position="frameTextPosition"
             :frame-style="frameStyle"
@@ -729,6 +772,31 @@ const mainContentContainer = ref<HTMLElement | null>(null)
               </div>
             </template>
           </QRCodeFrame>
+          <template v-else>
+            <div id="qr-code-container" class="grid place-items-center">
+              <div
+                class="grid place-items-center overflow-hidden"
+                :style="[
+                  style,
+                  {
+                    width: '200px',
+                    height: '200px'
+                  }
+                ]"
+              >
+                <StyledQRCode
+                  v-bind="{
+                    ...qrCodeProps,
+                    data: data?.length > 0 ? data : t('Have nice day!'),
+                    width: 200,
+                    height: 200
+                  }"
+                  role="img"
+                  aria-label="QR code"
+                />
+              </div>
+            </div>
+          </template>
         </div>
         <div class="mt-4 flex flex-col items-center gap-8">
           <div class="flex flex-col items-center justify-center gap-3">
@@ -908,6 +976,132 @@ const mainContentContainer = ref<HTMLElement | null>(null)
 
     <div id="settings" class="flex w-full grow flex-col items-start gap-8 text-start">
       <Accordion type="single" collapsible class="w-full" default-value="qr-code-settings">
+        <AccordionItem value="frame-settings">
+          <AccordionTrigger class="text-2xl font-semibold text-gray-700 dark:text-gray-100"
+            ><span class="flex flex-row items-center gap-2"
+              ><span>{{ t('Frame settings') }}</span>
+              <span
+                class="rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-800 dark:bg-zinc-700 dark:text-zinc-200"
+              >
+                {{ t('New!') }}
+              </span></span
+            ></AccordionTrigger
+          >
+          <AccordionContent>
+            <div class="space-y-4 pt-4">
+              <div class="flex flex-row items-center gap-2">
+                <label for="show-frame">{{ t('Add frame') }}</label>
+                <input id="show-frame" type="checkbox" class="checkbox" v-model="showFrame" />
+              </div>
+
+              <div v-if="showFrame">
+                <div class="mb-2 flex flex-row items-center gap-2">
+                  <label for="frame-text">{{ t('Frame text') }}</label>
+                </div>
+                <textarea
+                  name="frame-text"
+                  class="text-input"
+                  id="frame-text"
+                  rows="2"
+                  :placeholder="t('Text to display with QR code')"
+                  v-model="frameText"
+                />
+              </div>
+
+              <div v-if="showFrame">
+                <label class="mb-2 block">{{ t('Text position') }}</label>
+                <fieldset class="flex-1" role="radiogroup" tabindex="0">
+                  <div
+                    class="radiogroup"
+                    v-for="position in ['top', 'bottom', 'left', 'right']"
+                    :key="position"
+                  >
+                    <input
+                      :id="'frameTextPosition-' + position"
+                      type="radio"
+                      v-model="frameTextPosition"
+                      :value="position"
+                    />
+                    <label :for="'frameTextPosition-' + position">{{ t(position) }}</label>
+                  </div>
+                </fieldset>
+              </div>
+
+              <div v-if="showFrame">
+                <label class="mb-2 block">{{ t('Frame style') }}</label>
+                <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <div>
+                    <label for="frame-text-color" class="mb-1 block text-sm">{{
+                      t('Text color')
+                    }}</label>
+                    <input
+                      id="frame-text-color"
+                      type="color"
+                      class="color-input"
+                      v-model="frameStyle.textColor"
+                    />
+                  </div>
+                  <div>
+                    <label for="frame-bg-color" class="mb-1 block text-sm">{{
+                      t('Background color')
+                    }}</label>
+                    <input
+                      id="frame-bg-color"
+                      type="color"
+                      class="color-input"
+                      v-model="frameStyle.backgroundColor"
+                    />
+                  </div>
+                  <div>
+                    <label for="frame-border-color" class="mb-1 block text-sm">{{
+                      t('Border color')
+                    }}</label>
+                    <input
+                      id="frame-border-color"
+                      type="color"
+                      class="color-input"
+                      v-model="frameStyle.borderColor"
+                    />
+                  </div>
+                  <div>
+                    <label for="frame-border-width" class="mb-1 block text-sm">{{
+                      t('Border width')
+                    }}</label>
+                    <input
+                      id="frame-border-width"
+                      type="text"
+                      class="text-input"
+                      v-model="frameStyle.borderWidth"
+                      placeholder="1px"
+                    />
+                  </div>
+                  <div>
+                    <label for="frame-border-radius" class="mb-1 block text-sm">{{
+                      t('Border radius')
+                    }}</label>
+                    <input
+                      id="frame-border-radius"
+                      type="text"
+                      class="text-input"
+                      v-model="frameStyle.borderRadius"
+                      placeholder="8px"
+                    />
+                  </div>
+                  <div>
+                    <label for="frame-padding" class="mb-1 block text-sm">{{ t('Padding') }}</label>
+                    <input
+                      id="frame-padding"
+                      type="text"
+                      class="text-input"
+                      v-model="frameStyle.padding"
+                      placeholder="16px"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </AccordionContent>
+        </AccordionItem>
         <AccordionItem value="qr-code-settings">
           <AccordionTrigger class="text-2xl font-semibold text-gray-700 dark:text-gray-100">{{
             t('QR Code settings')
@@ -1348,124 +1542,6 @@ const mainContentContainer = ref<HTMLElement | null>(null)
                     <label :for="'cornersDotOptionsType-' + type">{{ t(type) }}</label>
                   </div>
                 </fieldset>
-              </div>
-            </div>
-          </AccordionContent>
-        </AccordionItem>
-
-        <AccordionItem value="frame-settings">
-          <AccordionTrigger class="text-2xl font-semibold text-gray-700 dark:text-gray-100"
-            ><span class="flex flex-row items-center gap-2"
-              ><span>{{ t('Frame settings') }}</span>
-              <span
-                class="rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-800 dark:bg-zinc-700 dark:text-zinc-200"
-              >
-                {{ t('New!') }}
-              </span></span
-            ></AccordionTrigger
-          >
-          <AccordionContent>
-            <div class="space-y-4 pt-4">
-              <div>
-                <div class="mb-2 flex flex-row items-center gap-2">
-                  <label for="frame-text">{{ t('Frame text') }}</label>
-                </div>
-                <textarea
-                  name="frame-text"
-                  class="text-input"
-                  id="frame-text"
-                  rows="2"
-                  :placeholder="t('Text to display with QR code')"
-                  v-model="frameText"
-                />
-              </div>
-
-              <div>
-                <label class="mb-2 block">{{ t('Text position') }}</label>
-                <div class="flex flex-wrap gap-2">
-                  <button
-                    v-for="position in ['top', 'bottom', 'left', 'right']"
-                    :key="position"
-                    class="secondary-button"
-                    :class="{ 'opacity-50': frameTextPosition !== position }"
-                    @click="frameTextPosition = position as 'top' | 'bottom' | 'left' | 'right'"
-                  >
-                    {{ t(position) }}
-                  </button>
-                </div>
-              </div>
-
-              <div>
-                <label class="mb-2 block">{{ t('Frame style') }}</label>
-                <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                  <div>
-                    <label for="frame-text-color" class="mb-1 block text-sm">{{
-                      t('Text color')
-                    }}</label>
-                    <input
-                      id="frame-text-color"
-                      type="color"
-                      class="color-input"
-                      v-model="frameStyle.textColor"
-                    />
-                  </div>
-                  <div>
-                    <label for="frame-bg-color" class="mb-1 block text-sm">{{
-                      t('Background color')
-                    }}</label>
-                    <input
-                      id="frame-bg-color"
-                      type="color"
-                      class="color-input"
-                      v-model="frameStyle.backgroundColor"
-                    />
-                  </div>
-                  <div>
-                    <label for="frame-border-color" class="mb-1 block text-sm">{{
-                      t('Border color')
-                    }}</label>
-                    <input
-                      id="frame-border-color"
-                      type="color"
-                      class="color-input"
-                      v-model="frameStyle.borderColor"
-                    />
-                  </div>
-                  <div>
-                    <label for="frame-border-width" class="mb-1 block text-sm">{{
-                      t('Border width')
-                    }}</label>
-                    <input
-                      id="frame-border-width"
-                      type="text"
-                      class="text-input"
-                      v-model="frameStyle.borderWidth"
-                      placeholder="1px"
-                    />
-                  </div>
-                  <div>
-                    <label for="frame-border-radius" class="mb-1 block text-sm">{{
-                      t('Border radius')
-                    }}</label>
-                    <input
-                      id="frame-border-radius"
-                      type="text"
-                      class="text-input"
-                      v-model="frameStyle.borderRadius"
-                      placeholder="8px"
-                    />
-                  </div>
-                  <div>
-                    <label for="frame-padding" class="mb-1 block text-sm">{{ t('Padding') }}</label>
-                    <input
-                      id="frame-padding"
-                      type="text"
-                      class="text-input"
-                      v-model="frameStyle.padding"
-                      placeholder="16px"
-                    />
-                  </div>
-                </div>
               </div>
             </div>
           </AccordionContent>

--- a/src/components/QRCodeCreate.vue
+++ b/src/components/QRCodeCreate.vue
@@ -377,11 +377,13 @@ function loadQRConfig(jsonString: string, key?: string) {
   if (key) {
     preset.name = key
     lastCustomLoadedPreset.value = preset
+    selectedPresetKey.value = key
   }
 
   selectedPreset.value = preset
 
-  // Load frame settings if they exist
+  showFrame.value = !!frameConfig
+
   if (frameConfig) {
     frameText.value = frameConfig.text || DEFAULT_FRAME_TEXT
     frameTextPosition.value = frameConfig.position || 'bottom'
@@ -424,7 +426,7 @@ function loadQRConfigFromLocalStorage() {
 }
 
 watch(
-  [qrCodeProps, style],
+  [qrCodeProps, style, showFrame],
   () => {
     saveQRConfigToLocalStorage()
   },

--- a/src/components/QRCodeCreate.vue
+++ b/src/components/QRCodeCreate.vue
@@ -652,12 +652,14 @@ async function generateBatchQRCodes(format: 'png' | 'svg' | 'jpg') {
 
 <template>
   <div class="flex items-start justify-center gap-4 pb-[180px] md:flex-row md:gap-12 md:pb-0">
+    <!-- Sticky sidebar on large screens -->
     <div
       v-if="isLarge"
       ref="mainContentContainer"
       id="main-content-container"
       class="sticky top-0 flex w-full shrink-0 flex-col items-center justify-center p-4 md:w-fit"
     ></div>
+    <!-- Bottom sheet on small screens -->
     <Drawer v-else>
       <DrawerTrigger
         id="drawer-preview-container"
@@ -682,7 +684,6 @@ async function generateBatchQRCodes(format: 'png' | 'svg' | 'jpg') {
                 <template #qr-code>
                   <div id="qr-code-container" class="grid place-items-center">
                     <div
-                      id="element-to-export"
                       class="grid place-items-center overflow-hidden"
                       :style="[
                         style,
@@ -765,6 +766,8 @@ async function generateBatchQRCodes(format: 'png' | 'svg' | 'jpg') {
         </div>
       </DrawerContent>
     </Drawer>
+
+    <!-- Main content -->
     <Teleport to="#main-content-container" v-if="mainContentContainer != null">
       <div id="main-content">
         <div
@@ -783,7 +786,6 @@ async function generateBatchQRCodes(format: 'png' | 'svg' | 'jpg') {
               <template #qr-code>
                 <div id="qr-code-container" class="grid place-items-center">
                   <div
-                    id="element-to-export"
                     class="grid place-items-center overflow-hidden"
                     :style="[
                       style,
@@ -810,7 +812,8 @@ async function generateBatchQRCodes(format: 'png' | 'svg' | 'jpg') {
           </div>
           <div
             v-else
-            class="grid place-items-center overflow-hidden"
+            id="element-to-export"
+            class="grid place-items-center"
             :style="[
               style,
               {

--- a/src/components/QRCodeCreate.vue
+++ b/src/components/QRCodeCreate.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import StyledQRCode from '@/components/StyledQRCode.vue'
+import QRCodeFrame from '@/components/QRCodeFrame.vue'
 import { Combobox } from '@/components/ui/Combobox'
 import { Drawer, DrawerContent, DrawerTitle, DrawerTrigger } from '@/components/ui/drawer'
 import { createRandomColor, getRandomItemInArray } from '@/utils/color'
@@ -27,6 +28,12 @@ import {
 import { computed, onMounted, ref, watch } from 'vue'
 import 'vue-i18n'
 import { useI18n } from 'vue-i18n'
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger
+} from '@/components/ui/accordion'
 
 // Define props
 const props = defineProps<{
@@ -67,6 +74,31 @@ const styleBorderRadius = ref()
 const styledBorderRadiusFormatted = computed(() => `${styleBorderRadius.value}px`)
 const styleBackground = ref(defaultPreset.style.background)
 const lastBackground = ref(defaultPreset.style.background)
+
+const DEFAULT_FRAME_TEXT = 'Scan for more info'
+const frameText = ref(DEFAULT_FRAME_TEXT)
+const frameTextPosition = ref<'top' | 'bottom' | 'left' | 'right'>('bottom')
+const frameStyle = ref({
+  textColor: '#000000',
+  backgroundColor: 'transparent',
+  borderColor: '',
+  borderWidth: '1px',
+  borderRadius: '8px',
+  padding: '16px'
+})
+
+function resetFrameTemplate() {
+  frameText.value = DEFAULT_FRAME_TEXT
+  frameTextPosition.value = 'bottom'
+  frameStyle.value = {
+    textColor: '#000000',
+    backgroundColor: 'transparent',
+    borderColor: '',
+    borderWidth: '1px',
+    borderRadius: '8px',
+    padding: '16px'
+  }
+}
 
 const includeBackground = ref(true)
 watch(
@@ -305,7 +337,12 @@ function uploadImage() {
 function createQrConfig() {
   return {
     props: qrCodeProps.value,
-    style: style.value
+    style: style.value,
+    frame: {
+      text: frameText.value,
+      position: frameTextPosition.value,
+      style: frameStyle.value
+    }
   }
 }
 
@@ -331,6 +368,8 @@ function loadQRConfig(jsonString: string, key?: string) {
   const qrCodeConfig = JSON.parse(jsonString)
   const qrCodeProps = qrCodeConfig.props
   const qrCodeStyle = qrCodeConfig.style
+  const frameConfig = qrCodeConfig.frame
+
   const preset = {
     ...qrCodeProps,
     style: qrCodeStyle
@@ -342,6 +381,16 @@ function loadQRConfig(jsonString: string, key?: string) {
   }
 
   selectedPreset.value = preset
+
+  // Load frame settings if they exist
+  if (frameConfig) {
+    frameText.value = frameConfig.text || DEFAULT_FRAME_TEXT
+    frameTextPosition.value = frameConfig.position || 'bottom'
+    frameStyle.value = {
+      ...frameStyle.value,
+      ...frameConfig.style
+    }
+  }
 }
 
 function loadQrConfigFromFile() {
@@ -648,29 +697,38 @@ const mainContentContainer = ref<HTMLElement | null>(null)
     </Drawer>
     <Teleport to="#main-content-container" v-if="mainContentContainer != null">
       <div id="main-content">
-        <div id="qr-code-container" class="grid place-items-center">
-          <div
-            ref="exportElementRef"
-            class="grid place-items-center overflow-hidden"
-            :style="[
-              style,
-              {
-                width: '200px',
-                height: '200px'
-              }
-            ]"
+        <div ref="exportElementRef">
+          <QRCodeFrame
+            :frame-text="frameText"
+            :text-position="frameTextPosition"
+            :frame-style="frameStyle"
           >
-            <StyledQRCode
-              v-bind="{
-                ...qrCodeProps,
-                data: data?.length > 0 ? data : t('Have nice day!'),
-                width: 200,
-                height: 200
-              }"
-              role="img"
-              aria-label="QR code"
-            />
-          </div>
+            <template #qr-code>
+              <div id="qr-code-container" class="grid place-items-center">
+                <div
+                  class="grid place-items-center overflow-hidden"
+                  :style="[
+                    style,
+                    {
+                      width: '200px',
+                      height: '200px'
+                    }
+                  ]"
+                >
+                  <StyledQRCode
+                    v-bind="{
+                      ...qrCodeProps,
+                      data: data?.length > 0 ? data : t('Have nice day!'),
+                      width: 200,
+                      height: 200
+                    }"
+                    role="img"
+                    aria-label="QR code"
+                  />
+                </div>
+              </div>
+            </template>
+          </QRCodeFrame>
         </div>
         <div class="mt-4 flex flex-col items-center gap-8">
           <div class="flex flex-col items-center justify-center gap-3">
@@ -849,391 +907,570 @@ const mainContentContainer = ref<HTMLElement | null>(null)
     </Teleport>
 
     <div id="settings" class="flex w-full grow flex-col items-start gap-8 text-start">
-      <div>
-        <label>{{ t('Preset') }}</label>
-        <div class="flex flex-row items-center justify-start gap-2">
-          <Combobox
-            :items="allPresetOptions"
-            v-model:value="selectedPresetKey"
-            v-model:open="isPresetSelectOpen"
-            :button-label="t('Select preset')"
-            :insert-divider-at-indexes="[0, 2]"
-          />
-          <button
-            class="icon-button"
-            @click="randomizeStyleSettings"
-            :aria-label="t('Randomize style')"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" width="40" height="32" viewBox="0 0 640 512">
-              <path
-                fill="#888888"
-                d="M274.9 34.3c-28.1-28.1-73.7-28.1-101.8 0L34.3 173.1c-28.1 28.1-28.1 73.7 0 101.8l138.8 138.8c28.1 28.1 73.7 28.1 101.8 0l138.8-138.8c28.1-28.1 28.1-73.7 0-101.8L274.9 34.3zM200 224a24 24 0 1 1 48 0a24 24 0 1 1-48 0zM96 200a24 24 0 1 1 0 48a24 24 0 1 1 0-48zm128 176a24 24 0 1 1 0-48a24 24 0 1 1 0 48zm128-176a24 24 0 1 1 0 48a24 24 0 1 1 0-48zm-128-80a24 24 0 1 1 0-48a24 24 0 1 1 0 48zm96 328c0 35.3 28.7 64 64 64h192c35.3 0 64-28.7 64-64V256c0-35.3-28.7-64-64-64H461.7c11.6 36 3.1 77-25.4 105.5L320 413.8V448zm160-120a24 24 0 1 1 0 48a24 24 0 1 1 0-48z"
-              />
-            </svg>
-          </button>
-        </div>
-      </div>
-      <div class="w-full">
-        <div class="flex w-full flex-col gap-4 sm:flex-row sm:gap-8">
-          <div class="w-full sm:w-2/3">
-            <div class="mb-2 flex items-center gap-4">
-              <label for="data">
-                {{ t('Data to encode') }}
-              </label>
-              <div class="flex grow items-center gap-2">
-                <button
-                  :class="['secondary-button', { 'opacity-50': exportMode !== ExportMode.Single }]"
-                  @click="exportMode = ExportMode.Single"
-                >
-                  {{ $t('Single export') }}
-                </button>
-                <button
-                  :class="['secondary-button', { 'opacity-50': exportMode !== ExportMode.Batch }]"
-                  @click="exportMode = ExportMode.Batch"
-                >
-                  {{ $t('Batch export') }}
-                </button>
-                <div
-                  v-if="exportMode === ExportMode.Batch"
-                  :class="[
-                    'flex grow items-center justify-end',
-                    dataStringsFromCsv.length > 0 && 'opacity-80'
-                  ]"
-                >
-                  <input
-                    id="ignore-header"
-                    type="checkbox"
-                    class="checkbox mr-2"
-                    v-model="ignoreHeaderRow"
-                    @change="onBatchInputFileUpload($event)"
+      <Accordion type="single" collapsible class="w-full" default-value="qr-code-settings">
+        <AccordionItem value="qr-code-settings">
+          <AccordionTrigger class="text-2xl font-semibold text-gray-700 dark:text-gray-100">{{
+            t('QR Code settings')
+          }}</AccordionTrigger>
+          <AccordionContent>
+            <div class="space-y-8 pt-4">
+              <div>
+                <label>{{ t('Preset') }}</label>
+                <div class="flex flex-row items-center justify-start gap-2">
+                  <Combobox
+                    :items="allPresetOptions"
+                    v-model:value="selectedPresetKey"
+                    v-model:open="isPresetSelectOpen"
+                    :button-label="t('Select preset')"
+                    :insert-divider-at-indexes="[0, 2]"
                   />
-                  <label for="ignore-header" class="!text-sm !font-normal">
-                    {{ $t('Ignore header row') }}
+                  <button
+                    class="icon-button"
+                    @click="randomizeStyleSettings"
+                    :aria-label="t('Randomize style')"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="40"
+                      height="32"
+                      viewBox="0 0 640 512"
+                    >
+                      <path
+                        fill="#888888"
+                        d="M274.9 34.3c-28.1-28.1-73.7-28.1-101.8 0L34.3 173.1c-28.1 28.1-28.1 73.7 0 101.8l138.8 138.8c28.1 28.1 73.7 28.1 101.8 0l138.8-138.8c28.1-28.1 28.1-73.7 0-101.8L274.9 34.3zM200 224a24 24 0 1 1 48 0a24 24 0 1 1-48 0zM96 200a24 24 0 1 1 0 48a24 24 0 1 1 0-48zm128 176a24 24 0 1 1 0-48a24 24 0 1 1 0 48zm128-176a24 24 0 1 1 0 48a24 24 0 1 1 0-48zm-128-80a24 24 0 1 1 0-48a24 24 0 1 1 0 48zm96 328c0 35.3 28.7 64 64 64h192c35.3 0 64-28.7 64-64V256c0-35.3-28.7-64-64-64H461.7c11.6 36 3.1 77-25.4 105.5L320 413.8V448zm160-120a24 24 0 1 1 0 48a24 24 0 1 1 0-48z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <div class="w-full">
+                <div class="flex w-full flex-col gap-4 sm:flex-row sm:gap-8">
+                  <div class="w-full sm:w-2/3">
+                    <div class="mb-2 flex items-center gap-4">
+                      <label for="data">
+                        {{ t('Data to encode') }}
+                      </label>
+                      <div class="flex grow items-center gap-2">
+                        <button
+                          :class="[
+                            'secondary-button',
+                            { 'opacity-50': exportMode !== ExportMode.Single }
+                          ]"
+                          @click="exportMode = ExportMode.Single"
+                        >
+                          {{ $t('Single export') }}
+                        </button>
+                        <button
+                          :class="[
+                            'secondary-button',
+                            { 'opacity-50': exportMode !== ExportMode.Batch }
+                          ]"
+                          @click="exportMode = ExportMode.Batch"
+                        >
+                          {{ $t('Batch export') }}
+                        </button>
+                        <div
+                          v-if="exportMode === ExportMode.Batch"
+                          :class="[
+                            'flex grow items-center justify-end',
+                            dataStringsFromCsv.length > 0 && 'opacity-80'
+                          ]"
+                        >
+                          <input
+                            id="ignore-header"
+                            type="checkbox"
+                            class="checkbox mr-2"
+                            v-model="ignoreHeaderRow"
+                            @change="onBatchInputFileUpload($event)"
+                          />
+                          <label for="ignore-header" class="!text-sm !font-normal">
+                            {{ $t('Ignore header row') }}
+                          </label>
+                        </div>
+                      </div>
+                    </div>
+                    <textarea
+                      v-if="exportMode === ExportMode.Single"
+                      name="data"
+                      class="text-input"
+                      id="data"
+                      :placeholder="t('data to encode e.g. a URL or a string')"
+                      v-model="data"
+                    />
+                    <template v-else>
+                      <template v-if="!inputFileForBatchEncoding">
+                        <button
+                          class="flex items-center justify-center rounded-lg border-2 border-dashed border-gray-300 p-1 py-4 text-center text-input"
+                          :aria-label="
+                            t('Click to select a text or CSV file containing data to encode')
+                          "
+                          @click="fileInput?.click()"
+                          @keyup.enter="fileInput?.click()"
+                          @keyup.space="fileInput?.click()"
+                          @dragover.prevent
+                          @drop.prevent="onBatchInputFileUpload"
+                        >
+                          <p aria-hidden="true">
+                            {{ $t('Upload a text/CSV file') }}
+                          </p>
+                          <input
+                            ref="fileInput"
+                            type="file"
+                            accept=".csv,.txt"
+                            class="hidden"
+                            @change="onBatchInputFileUpload"
+                          />
+                        </button>
+                        <p class="w-full text-end">
+                          <a
+                            href="/6_strings_batch.csv"
+                            download
+                            class="inline-flex items-center gap-1 text-sm text-zinc-500 hover:text-zinc-700 hover:underline dark:text-zinc-400 dark:hover:text-zinc-200"
+                          >
+                            {{ t('Example file') }}
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              width="16"
+                              height="16"
+                              viewBox="0 0 24 24"
+                              class="inline"
+                            >
+                              <path
+                                fill="currentColor"
+                                d="M12 15.575q-.2 0-.375-.063q-.175-.062-.325-.212l-3.6-3.6q-.275-.275-.275-.7q0-.425.275-.7q.275-.275.7-.275q.425 0 .7.275l1.9 1.9V4q0-.425.288-.713Q11.575 3 12 3t.713.287Q13 3.575 13 4v8.2l1.9-1.9q.275-.275.7-.275q.425 0 .7.275q.275.275.275.7q0 .425-.275.7l-3.6 3.6q-.15.15-.325.212q-.175.063-.375.063M6 21q-.825 0-1.413-.587Q4 19.825 4 19v-2q0-.425.287-.713Q4.575 16 5 16t.713.287Q6 16.575 6 17v2h12v-2q0-.425.288-.713Q18.575 16 19 16t.712.287Q20 16.575 20 17v2q0 .825-.587 1.413Q18.825 21 18 21m0-2q3.35 0 5.675-2.325T20 12t-2.325-5.675T12 4T6.325 6.325T4 12t2.325 5.675T12 20m.1-12.3q.625 0 1.088.4t.462 1q0 .55-.337.975t-.763.8q-.575.5-1.012 1.1t-.438 1.35q0 .35.263.588t.612.237q.375 0 .638-.25t.337-.625q.1-.525.45-.937t.75-.788q.575-.55.988-1.2t.412-1.45q0-1.275-1.037-2.087T12.1 6q-.95 0-1.812.4T8.975 7.625q-.175.3-.112.638t.337.512q.35.2.725.125t.625-.425q.275-.375.688-.575t.862-.2"
+                              />
+                            </svg>
+                          </a>
+                        </p>
+                      </template>
+                      <div v-else-if="isValidCsv" class="p-4 text-center">
+                        <div v-if="isBatchExportSuccess">
+                          <p>{{ $t('QR codes have been successfully exported.') }}</p>
+                          <button class="button mt-4" @click="inputFileForBatchEncoding = null">
+                            {{ $t('Start new batch export') }}
+                          </button>
+                        </div>
+                        <div v-else-if="currentExportedQrCodeIndex == null && !isExportingBatchQRs">
+                          <p>
+                            {{
+                              $t('{count} piece(s) of data detected', {
+                                count: filteredDataStringsFromCsv.length
+                              })
+                            }}
+                          </p>
+                          <div v-if="dataStringsFromCsv.length > 0" class="mt-4 text-start">
+                            <p class="text-center text-sm text-zinc-500">
+                              <span class="me-2">{{ $t('First row preview:') }}</span>
+                              <span class="inline-block">
+                                <pre class="rounded bg-gray-200 text-sm">{{
+                                  `${ignoreHeaderRow ? dataStringsFromCsv[1] : dataStringsFromCsv[0]}`
+                                }}</pre>
+                              </span>
+                            </p>
+                          </div>
+                        </div>
+                        <div v-else-if="currentExportedQrCodeIndex != null">
+                          <p>{{ $t('Creating QR codes... This may take a while.') }}</p>
+                          <p>
+                            {{
+                              $t('{index} / {count} QR codes have been created.', {
+                                index: currentExportedQrCodeIndex + 1,
+                                count: filteredDataStringsFromCsv.length
+                              })
+                            }}
+                          </p>
+                        </div>
+                      </div>
+                      <div v-else class="p-4 text-center text-red-500">
+                        <p>{{ $t('Invalid CSV') }}</p>
+                      </div>
+                    </template>
+                  </div>
+
+                  <div class="w-full sm:w-1/3 sm:border-l-2 sm:border-gray-300 sm:pl-4">
+                    <fieldset class="h-full" role="radiogroup" tabindex="0">
+                      <div class="flex flex-row items-center gap-2">
+                        <legend>{{ t('Error correction level') }}</legend>
+                        <a
+                          href="https://docs.uniqode.com/en/articles/7219782-what-is-the-recommended-error-correction-level-for-printing-a-qr-code"
+                          target="_blank"
+                          class="icon-button flex flex-row items-center"
+                          :aria-label="t('What is error correction level?')"
+                        >
+                          <svg
+                            class="me-1"
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="16"
+                            height="16"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              fill="#888888"
+                              d="M11.95 18q.525 0 .888-.363t.362-.887t-.362-.888t-.888-.362t-.887.363t-.363.887t.363.888t.887.362m.05 4q-2.075 0-3.9-.788t-3.175-2.137T2.788 15.9T2 12t.788-3.9t2.137-3.175T8.1 2.788T12 2t3.9.788t3.175 2.137T21.213 8.1T22 12t-.788 3.9t-2.137 3.175t-3.175 2.138T12 22m0-2q3.35 0 5.675-2.325T20 12t-2.325-5.675T12 4T6.325 6.325T4 12t2.325 5.675T12 20m.1-12.3q.625 0 1.088.4t.462 1q0 .55-.337.975t-.763.8q-.575.5-1.012 1.1t-.438 1.35q0 .35.263.588t.612.237q.375 0 .638-.25t.337-.625q.1-.525.45-.937t.75-.788q.575-.55.988-1.2t.412-1.45q0-1.275-1.037-2.087T12.1 6q-.95 0-1.812.4T8.975 7.625q-.175.3-.112.638t.337.512q.35.2.725.125t.625-.425q.275-.375.688-.575t.862-.2"
+                            />
+                          </svg>
+                        </a>
+                      </div>
+                      <div v-for="level in errorCorrectionLevels" class="radiogroup" :key="level">
+                        <input
+                          :id="'errorCorrectionLevel-' + level"
+                          type="radio"
+                          v-model="errorCorrectionLevel"
+                          :value="level"
+                          :aria-describedby="
+                            level === recommendedErrorCorrectionLevel
+                              ? 'recommended-text'
+                              : undefined
+                          "
+                        />
+                        <div class="flex items-center gap-2">
+                          <label :for="'errorCorrectionLevel-' + level">{{
+                            t(ERROR_CORRECTION_LEVEL_LABELS[level])
+                          }}</label>
+                          <span
+                            v-if="level === recommendedErrorCorrectionLevel"
+                            class="inline-flex items-center rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-800 dark:bg-zinc-700 dark:text-zinc-200"
+                          >
+                            {{ t('Suggested') }}
+                          </span>
+                        </div>
+                      </div>
+                    </fieldset>
+                  </div>
+                </div>
+              </div>
+              <div class="w-full">
+                <div class="mb-2 flex flex-row items-center gap-2">
+                  <label for="image-url">
+                    {{ t('Logo image URL') }}
                   </label>
+                  <button class="icon-button flex flex-row items-center" @click="uploadImage">
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="24"
+                      height="24"
+                      viewBox="0 0 24 24"
+                    >
+                      <g
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      >
+                        <path d="M14 3v4a1 1 0 0 0 1 1h4" />
+                        <path
+                          d="M17 21H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h7l5 5v11a2 2 0 0 1-2 2zm-5-10v6"
+                        />
+                        <path d="M9.5 13.5L12 11l2.5 2.5" />
+                      </g>
+                    </svg>
+                    <span>{{ t('Upload image') }}</span>
+                  </button>
+                </div>
+                <textarea
+                  name="image-url"
+                  class="text-input"
+                  id="image-url"
+                  rows="1"
+                  :placeholder="t('Logo image URL')"
+                  v-model="image"
+                />
+              </div>
+              <div class="flex flex-row items-center gap-2">
+                <label for="with-background">
+                  {{ t('With background') }}
+                </label>
+                <input
+                  id="with-background"
+                  type="checkbox"
+                  class="checkbox"
+                  v-model="includeBackground"
+                />
+              </div>
+              <div id="color-settings" :class="'flex w-full flex-row flex-wrap gap-4'">
+                <div
+                  :inert="!includeBackground"
+                  :class="[!includeBackground && 'opacity-30', 'flex flex-row items-center gap-2']"
+                >
+                  <label for="background-color">{{ t('Background color') }}</label>
+                  <input
+                    id="background-color"
+                    type="color"
+                    class="color-input"
+                    v-model="styleBackground"
+                  />
+                </div>
+                <div class="flex flex-row items-center gap-2">
+                  <label for="dots-color">{{ t('Dots color') }}</label>
+                  <input
+                    id="dots-color"
+                    type="color"
+                    class="color-input"
+                    v-model="dotsOptionsColor"
+                  />
+                </div>
+                <div class="flex flex-row items-center gap-2">
+                  <label for="corners-square-color">{{ t('Corners Square color') }}</label>
+                  <input
+                    id="corners-square-color"
+                    type="color"
+                    class="color-input"
+                    v-model="cornersSquareOptionsColor"
+                  />
+                </div>
+                <div class="flex flex-row items-center gap-2">
+                  <label for="corners-dot-color">{{ t('Corners Dot color') }}</label>
+                  <input
+                    id="corners-dot-color"
+                    type="color"
+                    class="color-input"
+                    v-model="cornersDotOptionsColor"
+                  />
+                </div>
+              </div>
+              <div class="flex w-full flex-col gap-4 sm:flex-row sm:gap-8">
+                <div class="w-full sm:w-1/3">
+                  <label for="width">
+                    {{ t('Width (px)') }}
+                  </label>
+                  <input
+                    class="text-input"
+                    id="width"
+                    type="number"
+                    placeholder="width in pixels"
+                    v-model="width"
+                  />
+                </div>
+                <div class="w-full sm:w-1/3">
+                  <label for="height">
+                    {{ t('Height (px)') }}
+                  </label>
+                  <input
+                    class="text-input"
+                    id="height"
+                    type="number"
+                    placeholder="height in pixels"
+                    v-model="height"
+                  />
+                </div>
+                <div class="w-full sm:w-1/3">
+                  <label for="border-radius">
+                    {{ t('Border radius (px)') }}
+                  </label>
+                  <input
+                    class="text-input"
+                    id="border-radius"
+                    type="number"
+                    placeholder="24"
+                    v-model="styleBorderRadius"
+                  />
+                </div>
+              </div>
+              <div class="flex w-full flex-col gap-4 sm:flex-row sm:gap-8">
+                <div class="w-full sm:w-1/2">
+                  <label for="margin">
+                    {{ t('Margin (px)') }}
+                  </label>
+                  <input
+                    class="text-input"
+                    id="margin"
+                    type="number"
+                    placeholder="0"
+                    v-model="margin"
+                  />
+                </div>
+                <div class="w-full sm:w-1/2">
+                  <label for="image-margin">
+                    {{ t('Image margin (px)') }}
+                  </label>
+                  <input
+                    class="text-input"
+                    id="image-margin"
+                    type="number"
+                    placeholder="0"
+                    v-model="imageMargin"
+                  />
+                </div>
+              </div>
+              <div
+                id="dots-squares-settings"
+                class="mb-4 flex w-full flex-col flex-wrap gap-6 md:flex-row"
+              >
+                <fieldset class="flex-1" role="radiogroup" tabindex="0">
+                  <legend>{{ t('Dots type') }}</legend>
+                  <div
+                    class="radiogroup"
+                    v-for="type in [
+                      'dots',
+                      'rounded',
+                      'classy',
+                      'classy-rounded',
+                      'square',
+                      'extra-rounded'
+                    ]"
+                    :key="type"
+                  >
+                    <input
+                      :id="'dotsOptionsType-' + type"
+                      type="radio"
+                      v-model="dotsOptionsType"
+                      :value="type"
+                    />
+                    <label :for="'dotsOptionsType-' + type">{{ t(type) }}</label>
+                  </div>
+                </fieldset>
+                <fieldset class="flex-1" role="radiogroup" tabindex="0">
+                  <legend>{{ t('Corners Square type') }}</legend>
+                  <div
+                    class="radiogroup"
+                    v-for="type in ['dot', 'square', 'extra-rounded']"
+                    :key="type"
+                  >
+                    <input
+                      :id="'cornersSquareOptionsType-' + type"
+                      type="radio"
+                      v-model="cornersSquareOptionsType"
+                      :value="type"
+                    />
+                    <label :for="'cornersSquareOptionsType-' + type">{{ t(type) }}</label>
+                  </div>
+                </fieldset>
+                <fieldset class="flex-1" role="radiogroup" tabindex="0">
+                  <legend>{{ t('Corners Dot type') }}</legend>
+                  <div class="radiogroup" v-for="type in ['dot', 'square']" :key="type">
+                    <input
+                      :id="'cornersDotOptionsType-' + type"
+                      type="radio"
+                      v-model="cornersDotOptionsType"
+                      :value="type"
+                    />
+                    <label :for="'cornersDotOptionsType-' + type">{{ t(type) }}</label>
+                  </div>
+                </fieldset>
+              </div>
+            </div>
+          </AccordionContent>
+        </AccordionItem>
+
+        <AccordionItem value="frame-settings">
+          <AccordionTrigger class="text-2xl font-semibold text-gray-700 dark:text-gray-100"
+            ><span class="flex flex-row items-center gap-2"
+              ><span>{{ t('Frame settings') }}</span>
+              <span
+                class="rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-800 dark:bg-zinc-700 dark:text-zinc-200"
+              >
+                {{ t('New!') }}
+              </span></span
+            ></AccordionTrigger
+          >
+          <AccordionContent>
+            <div class="space-y-4 pt-4">
+              <div>
+                <div class="mb-2 flex flex-row items-center gap-2">
+                  <label for="frame-text">{{ t('Frame text') }}</label>
+                </div>
+                <textarea
+                  name="frame-text"
+                  class="text-input"
+                  id="frame-text"
+                  rows="2"
+                  :placeholder="t('Text to display with QR code')"
+                  v-model="frameText"
+                />
+              </div>
+
+              <div>
+                <label class="mb-2 block">{{ t('Text position') }}</label>
+                <div class="flex flex-wrap gap-2">
+                  <button
+                    v-for="position in ['top', 'bottom', 'left', 'right']"
+                    :key="position"
+                    class="secondary-button"
+                    :class="{ 'opacity-50': frameTextPosition !== position }"
+                    @click="frameTextPosition = position as 'top' | 'bottom' | 'left' | 'right'"
+                  >
+                    {{ t(position) }}
+                  </button>
+                </div>
+              </div>
+
+              <div>
+                <label class="mb-2 block">{{ t('Frame style') }}</label>
+                <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <div>
+                    <label for="frame-text-color" class="mb-1 block text-sm">{{
+                      t('Text color')
+                    }}</label>
+                    <input
+                      id="frame-text-color"
+                      type="color"
+                      class="color-input"
+                      v-model="frameStyle.textColor"
+                    />
+                  </div>
+                  <div>
+                    <label for="frame-bg-color" class="mb-1 block text-sm">{{
+                      t('Background color')
+                    }}</label>
+                    <input
+                      id="frame-bg-color"
+                      type="color"
+                      class="color-input"
+                      v-model="frameStyle.backgroundColor"
+                    />
+                  </div>
+                  <div>
+                    <label for="frame-border-color" class="mb-1 block text-sm">{{
+                      t('Border color')
+                    }}</label>
+                    <input
+                      id="frame-border-color"
+                      type="color"
+                      class="color-input"
+                      v-model="frameStyle.borderColor"
+                    />
+                  </div>
+                  <div>
+                    <label for="frame-border-width" class="mb-1 block text-sm">{{
+                      t('Border width')
+                    }}</label>
+                    <input
+                      id="frame-border-width"
+                      type="text"
+                      class="text-input"
+                      v-model="frameStyle.borderWidth"
+                      placeholder="1px"
+                    />
+                  </div>
+                  <div>
+                    <label for="frame-border-radius" class="mb-1 block text-sm">{{
+                      t('Border radius')
+                    }}</label>
+                    <input
+                      id="frame-border-radius"
+                      type="text"
+                      class="text-input"
+                      v-model="frameStyle.borderRadius"
+                      placeholder="8px"
+                    />
+                  </div>
+                  <div>
+                    <label for="frame-padding" class="mb-1 block text-sm">{{ t('Padding') }}</label>
+                    <input
+                      id="frame-padding"
+                      type="text"
+                      class="text-input"
+                      v-model="frameStyle.padding"
+                      placeholder="16px"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
-            <textarea
-              v-if="exportMode === ExportMode.Single"
-              name="data"
-              class="text-input"
-              id="data"
-              :placeholder="t('data to encode e.g. a URL or a string')"
-              v-model="data"
-            />
-            <template v-else>
-              <template v-if="!inputFileForBatchEncoding">
-                <button
-                  class="flex items-center justify-center rounded-lg border-2 border-dashed border-gray-300 p-1 py-4 text-center text-input"
-                  :aria-label="t('Click to select a text or CSV file containing data to encode')"
-                  @click="fileInput?.click()"
-                  @keyup.enter="fileInput?.click()"
-                  @keyup.space="fileInput?.click()"
-                  @dragover.prevent
-                  @drop.prevent="onBatchInputFileUpload"
-                >
-                  <p aria-hidden="true">
-                    {{ $t('Upload a text/CSV file') }}
-                  </p>
-                  <input
-                    ref="fileInput"
-                    type="file"
-                    accept=".csv,.txt"
-                    class="hidden"
-                    @change="onBatchInputFileUpload"
-                  />
-                </button>
-                <p class="w-full text-end">
-                  <a
-                    href="/6_strings_batch.csv"
-                    download
-                    class="inline-flex items-center gap-1 text-sm text-zinc-500 hover:text-zinc-700 hover:underline dark:text-zinc-400 dark:hover:text-zinc-200"
-                  >
-                    {{ t('Example file') }}
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="16"
-                      height="16"
-                      viewBox="0 0 24 24"
-                      class="inline"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M12 15.575q-.2 0-.375-.063q-.175-.062-.325-.212l-3.6-3.6q-.275-.275-.275-.7q0-.425.275-.7q.275-.275.7-.275q.425 0 .7.275l1.9 1.9V4q0-.425.288-.713Q11.575 3 12 3t.713.287Q13 3.575 13 4v8.2l1.9-1.9q.275-.275.7-.275q.425 0 .7.275q.275.275.275.7q0 .425-.275.7l-3.6 3.6q-.15.15-.325.212q-.175.063-.375.063M6 21q-.825 0-1.413-.587Q4 19.825 4 19v-2q0-.425.287-.713Q4.575 16 5 16t.713.287Q6 16.575 6 17v2h12v-2q0-.425.288-.713Q18.575 16 19 16t.712.287Q20 16.575 20 17v2q0 .825-.587 1.413Q18.825 21 18 21m0-2q3.35 0 5.675-2.325T20 12t-2.325-5.675T12 4T6.325 6.325T4 12t2.325 5.675T12 20m.1-12.3q.625 0 1.088.4t.462 1q0 .55-.337.975t-.763.8q-.575.5-1.012 1.1t-.438 1.35q0 .35.263.588t.612.237q.375 0 .638-.25t.337-.625q.1-.525.45-.937t.75-.788q.575-.55.988-1.2t.412-1.45q0-1.275-1.037-2.087T12.1 6q-.95 0-1.812.4T8.975 7.625q-.175.3-.112.638t.337.512q.35.2.725.125t.625-.425q.275-.375.688-.575t.862-.2"
-                      />
-                    </svg>
-                  </a>
-                </p>
-              </template>
-              <div v-else-if="isValidCsv" class="p-4 text-center">
-                <div v-if="isBatchExportSuccess">
-                  <p>{{ $t('QR codes have been successfully exported.') }}</p>
-                  <button class="button mt-4" @click="inputFileForBatchEncoding = null">
-                    {{ $t('Start new batch export') }}
-                  </button>
-                </div>
-                <div v-else-if="currentExportedQrCodeIndex == null && !isExportingBatchQRs">
-                  <p>
-                    {{
-                      $t('{count} piece(s) of data detected', {
-                        count: filteredDataStringsFromCsv.length
-                      })
-                    }}
-                  </p>
-                  <div v-if="dataStringsFromCsv.length > 0" class="mt-4 text-start">
-                    <p class="text-center text-sm text-zinc-500">
-                      <span class="me-2">{{ $t('First row preview:') }}</span>
-                      <span class="inline-block">
-                        <pre class="rounded bg-gray-200 text-sm">{{
-                          `${ignoreHeaderRow ? dataStringsFromCsv[1] : dataStringsFromCsv[0]}`
-                        }}</pre>
-                      </span>
-                    </p>
-                  </div>
-                </div>
-                <div v-else-if="currentExportedQrCodeIndex != null">
-                  <p>{{ $t('Creating QR codes... This may take a while.') }}</p>
-                  <p>
-                    {{
-                      $t('{index} / {count} QR codes have been created.', {
-                        index: currentExportedQrCodeIndex + 1,
-                        count: filteredDataStringsFromCsv.length
-                      })
-                    }}
-                  </p>
-                </div>
-              </div>
-              <div v-else class="p-4 text-center text-red-500">
-                <p>{{ $t('Invalid CSV') }}</p>
-              </div>
-            </template>
-          </div>
-
-          <div class="w-full sm:w-1/3 sm:border-l-2 sm:border-gray-300 sm:pl-4">
-            <fieldset class="h-full" role="radiogroup" tabindex="0">
-              <div class="flex flex-row items-center gap-2">
-                <legend>{{ t('Error correction level') }}</legend>
-                <a
-                  href="https://docs.uniqode.com/en/articles/7219782-what-is-the-recommended-error-correction-level-for-printing-a-qr-code"
-                  target="_blank"
-                  class="icon-button flex flex-row items-center"
-                  :aria-label="t('What is error correction level?')"
-                >
-                  <svg
-                    class="me-1"
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="16"
-                    height="16"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      fill="#888888"
-                      d="M11.95 18q.525 0 .888-.363t.362-.887t-.362-.888t-.888-.362t-.887.363t-.363.887t.363.888t.887.362m.05 4q-2.075 0-3.9-.788t-3.175-2.137T2.788 15.9T2 12t.788-3.9t2.137-3.175T8.1 2.788T12 2t3.9.788t3.175 2.137T21.213 8.1T22 12t-.788 3.9t-2.137 3.175t-3.175 2.138T12 22m0-2q3.35 0 5.675-2.325T20 12t-2.325-5.675T12 4T6.325 6.325T4 12t2.325 5.675T12 20m.1-12.3q.625 0 1.088.4t.462 1q0 .55-.337.975t-.763.8q-.575.5-1.012 1.1t-.438 1.35q0 .35.263.588t.612.237q.375 0 .638-.25t.337-.625q.1-.525.45-.937t.75-.788q.575-.55.988-1.2t.412-1.45q0-1.275-1.037-2.087T12.1 6q-.95 0-1.812.4T8.975 7.625q-.175.3-.112.638t.337.512q.35.2.725.125t.625-.425q.275-.375.688-.575t.862-.2"
-                    />
-                  </svg>
-                </a>
-              </div>
-              <div v-for="level in errorCorrectionLevels" class="radiogroup" :key="level">
-                <input
-                  :id="'errorCorrectionLevel-' + level"
-                  type="radio"
-                  v-model="errorCorrectionLevel"
-                  :value="level"
-                  :aria-describedby="
-                    level === recommendedErrorCorrectionLevel ? 'recommended-text' : undefined
-                  "
-                />
-                <div class="flex items-center gap-2">
-                  <label :for="'errorCorrectionLevel-' + level">{{
-                    t(ERROR_CORRECTION_LEVEL_LABELS[level])
-                  }}</label>
-                  <span
-                    v-if="level === recommendedErrorCorrectionLevel"
-                    class="inline-flex items-center rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-800 dark:bg-zinc-700 dark:text-zinc-200"
-                  >
-                    {{ t('Suggested') }}
-                  </span>
-                </div>
-              </div>
-            </fieldset>
-          </div>
-        </div>
-      </div>
-      <div class="w-full">
-        <div class="mb-2 flex flex-row items-center gap-2">
-          <label for="image-url">
-            {{ t('Logo image URL') }}
-          </label>
-          <button class="icon-button flex flex-row items-center" @click="uploadImage">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-              <g
-                fill="none"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              >
-                <path d="M14 3v4a1 1 0 0 0 1 1h4" />
-                <path d="M17 21H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h7l5 5v11a2 2 0 0 1-2 2zm-5-10v6" />
-                <path d="M9.5 13.5L12 11l2.5 2.5" />
-              </g>
-            </svg>
-            <span>{{ t('Upload image') }}</span>
-          </button>
-        </div>
-        <textarea
-          name="image-url"
-          class="text-input"
-          id="image-url"
-          rows="1"
-          :placeholder="t('Logo image URL')"
-          v-model="image"
-        />
-      </div>
-      <div class="flex flex-row items-center gap-2">
-        <label for="with-background">
-          {{ t('With background') }}
-        </label>
-        <input id="with-background" type="checkbox" class="checkbox" v-model="includeBackground" />
-      </div>
-      <div id="color-settings" :class="'flex w-full flex-row flex-wrap gap-4'">
-        <div
-          :inert="!includeBackground"
-          :class="[!includeBackground && 'opacity-30', 'flex flex-row items-center gap-2']"
-        >
-          <label for="background-color">{{ t('Background color') }}</label>
-          <input id="background-color" type="color" class="color-input" v-model="styleBackground" />
-        </div>
-        <div class="flex flex-row items-center gap-2">
-          <label for="dots-color">{{ t('Dots color') }}</label>
-          <input id="dots-color" type="color" class="color-input" v-model="dotsOptionsColor" />
-        </div>
-        <div class="flex flex-row items-center gap-2">
-          <label for="corners-square-color">{{ t('Corners Square color') }}</label>
-          <input
-            id="corners-square-color"
-            type="color"
-            class="color-input"
-            v-model="cornersSquareOptionsColor"
-          />
-        </div>
-        <div class="flex flex-row items-center gap-2">
-          <label for="corners-dot-color">{{ t('Corners Dot color') }}</label>
-          <input
-            id="corners-dot-color"
-            type="color"
-            class="color-input"
-            v-model="cornersDotOptionsColor"
-          />
-        </div>
-      </div>
-      <div class="flex w-full flex-col gap-4 sm:flex-row sm:gap-8">
-        <div class="w-full sm:w-1/3">
-          <label for="width">
-            {{ t('Width (px)') }}
-          </label>
-          <input
-            class="text-input"
-            id="width"
-            type="number"
-            placeholder="width in pixels"
-            v-model="width"
-          />
-        </div>
-        <div class="w-full sm:w-1/3">
-          <label for="height">
-            {{ t('Height (px)') }}
-          </label>
-          <input
-            class="text-input"
-            id="height"
-            type="number"
-            placeholder="height in pixels"
-            v-model="height"
-          />
-        </div>
-        <div class="w-full sm:w-1/3">
-          <label for="border-radius">
-            {{ t('Border radius (px)') }}
-          </label>
-          <input
-            class="text-input"
-            id="border-radius"
-            type="number"
-            placeholder="24"
-            v-model="styleBorderRadius"
-          />
-        </div>
-      </div>
-      <div class="flex w-full flex-col gap-4 sm:flex-row sm:gap-8">
-        <div class="w-full sm:w-1/2">
-          <label for="margin">
-            {{ t('Margin (px)') }}
-          </label>
-          <input class="text-input" id="margin" type="number" placeholder="0" v-model="margin" />
-        </div>
-        <div class="w-full sm:w-1/2">
-          <label for="image-margin">
-            {{ t('Image margin (px)') }}
-          </label>
-          <input
-            class="text-input"
-            id="image-margin"
-            type="number"
-            placeholder="0"
-            v-model="imageMargin"
-          />
-        </div>
-      </div>
-      <div id="dots-squares-settings" class="mb-4 flex w-full flex-col flex-wrap gap-6 md:flex-row">
-        <fieldset class="flex-1" role="radiogroup" tabindex="0">
-          <legend>{{ t('Dots type') }}</legend>
-          <div
-            class="radiogroup"
-            v-for="type in [
-              'dots',
-              'rounded',
-              'classy',
-              'classy-rounded',
-              'square',
-              'extra-rounded'
-            ]"
-            :key="type"
-          >
-            <input
-              :id="'dotsOptionsType-' + type"
-              type="radio"
-              v-model="dotsOptionsType"
-              :value="type"
-            />
-            <label :for="'dotsOptionsType-' + type">{{ t(type) }}</label>
-          </div>
-        </fieldset>
-        <fieldset class="flex-1" role="radiogroup" tabindex="0">
-          <legend>{{ t('Corners Square type') }}</legend>
-          <div class="radiogroup" v-for="type in ['dot', 'square', 'extra-rounded']" :key="type">
-            <input
-              :id="'cornersSquareOptionsType-' + type"
-              type="radio"
-              v-model="cornersSquareOptionsType"
-              :value="type"
-            />
-            <label :for="'cornersSquareOptionsType-' + type">{{ t(type) }}</label>
-          </div>
-        </fieldset>
-        <fieldset class="flex-1" role="radiogroup" tabindex="0">
-          <legend>{{ t('Corners Dot type') }}</legend>
-          <div class="radiogroup" v-for="type in ['dot', 'square']" :key="type">
-            <input
-              :id="'cornersDotOptionsType-' + type"
-              type="radio"
-              v-model="cornersDotOptionsType"
-              :value="type"
-            />
-            <label :for="'cornersDotOptionsType-' + type">{{ t(type) }}</label>
-          </div>
-        </fieldset>
-      </div>
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
     </div>
   </div>
 </template>

--- a/src/components/QRCodeCreate.vue
+++ b/src/components/QRCodeCreate.vue
@@ -663,17 +663,12 @@ async function generateBatchQRCodes(format: 'png' | 'svg' | 'jpg') {
     <Drawer v-else>
       <DrawerTrigger
         id="drawer-preview-container"
-        class="fixed inset-x-0 bottom-0 rounded-t-lg border-t border-solid border-slate-300 bg-white shadow-2xl dark:bg-black"
+        class="fixed inset-x-0 bottom-0 rounded-t-lg border-t border-solid border-slate-300 bg-white shadow-2xl outline-none focus-visible:ring-1 focus-visible:ring-zinc-700 dark:bg-black dark:focus-visible:ring-zinc-200"
       >
         <div class="flex flex-col items-center">
           <!-- Handle indicator for bottom sheet -->
           <div class="mt-2 h-1 w-16 rounded-full bg-gray-300 dark:bg-gray-700"></div>
-          <div
-            :class="[
-              'w-full',
-              showFrame && ['left', 'right'].includes(frameTextPosition) ? '-my-4' : '-my-8'
-            ]"
-          >
+          <div :class="['w-full', '-my-8']">
             <div class="flex origin-center scale-[0.7] items-center justify-center md:scale-100">
               <QRCodeFrame
                 v-if="showFrame"
@@ -735,7 +730,7 @@ async function generateBatchQRCodes(format: 'png' | 'svg' | 'jpg') {
             </div>
           </div>
           <div
-            class="flex items-center gap-1 pb-2 text-center text-sm text-gray-600 dark:text-gray-400"
+            class="flex items-center gap-1 py-2 text-center text-sm text-gray-600 dark:text-gray-400"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"

--- a/src/components/QRCodeCreate.vue
+++ b/src/components/QRCodeCreate.vue
@@ -217,7 +217,6 @@ watch(selectedPreset, () => {
       ? selectedPreset.value.qrOptions.errorCorrectionLevel
       : 'Q'
   // Most presets don't have a frame, so we set it to false by default
-  showFrame.value = false
 })
 
 const LAST_LOADED_LOCALLY_PRESET_KEY = 'Last saved locally'
@@ -280,6 +279,11 @@ const frameStyle = ref<FrameStyle>({
   borderRadius: '8px',
   padding: '16px'
 })
+const frameSettings = computed(() => ({
+  text: frameText.value,
+  position: frameTextPosition.value,
+  style: frameStyle.value
+}))
 //#endregion
 
 //#region /* General Export - download qr code and copy to clipboard */
@@ -382,13 +386,7 @@ function createQrConfig(): QRCodeConfig {
   return {
     props: qrCodeProps.value,
     style: style.value,
-    frame: showFrame.value
-      ? {
-          text: frameText.value,
-          position: frameTextPosition.value,
-          style: frameStyle.value
-        }
-      : null
+    frame: showFrame.value ? frameSettings.value : null
   }
 }
 
@@ -472,7 +470,7 @@ function loadQRConfigFromLocalStorage() {
 }
 
 watch(
-  [qrCodeProps, style, showFrame],
+  [qrCodeProps, style, showFrame, frameSettings],
   () => {
     saveQRConfigToLocalStorage()
   },

--- a/src/components/QRCodeCreate.vue
+++ b/src/components/QRCodeCreate.vue
@@ -35,11 +35,11 @@ import {
   AccordionTrigger
 } from '@/components/ui/accordion'
 
-// Define props
 const props = defineProps<{
   initialData?: string
 }>()
 
+const PREVIEW_QRCODE_DIM_UNIT = 200
 const isLarge = useMediaQuery('(min-width: 768px)')
 
 //#region /** locale */
@@ -247,10 +247,19 @@ const recommendedErrorCorrectionLevel = computed<ErrorCorrectionLevel | null>(()
 //#endregion
 
 //#region /* export image utils */
-const options = computed(() => ({
-  width: width.value,
-  height: height.value
-}))
+const options = computed(() => {
+  if (!showFrame.value) {
+    return {
+      width: width.value,
+      height: height.value
+    }
+  }
+
+  return {
+    width: (elementToBeExported.value.offsetWidth / PREVIEW_QRCODE_DIM_UNIT) * width.value,
+    height: (elementToBeExported.value.offsetHeight / PREVIEW_QRCODE_DIM_UNIT) * height.value
+  }
+})
 
 const exportElementRef = ref<HTMLElement | null>(null)
 const elementToBeExported = computed(() => exportElementRef.value as HTMLElement)
@@ -726,7 +735,7 @@ const mainContentContainer = ref<HTMLElement | null>(null)
     <Teleport to="#main-content-container" v-if="mainContentContainer != null">
       <div id="main-content">
         <div id="qr-code-container" class="grid place-items-center">
-          <div v-if="showFrame" ref="exportElementRef" class="w-fit">
+          <div v-if="showFrame" ref="exportElementRef">
             <QRCodeFrame
               :frame-text="frameText"
               :text-position="frameTextPosition"
@@ -749,8 +758,8 @@ const mainContentContainer = ref<HTMLElement | null>(null)
                       v-bind="{
                         ...qrCodeProps,
                         data: data?.length > 0 ? data : t('Have nice day!'),
-                        width: 200,
-                        height: 200
+                        width: PREVIEW_QRCODE_DIM_UNIT,
+                        height: PREVIEW_QRCODE_DIM_UNIT
                       }"
                       role="img"
                       aria-label="QR code"
@@ -766,8 +775,8 @@ const mainContentContainer = ref<HTMLElement | null>(null)
             :style="[
               style,
               {
-                width: '200px',
-                height: '200px'
+                width: `${PREVIEW_QRCODE_DIM_UNIT}px`,
+                height: `${PREVIEW_QRCODE_DIM_UNIT}px`
               }
             ]"
             ref="exportElementRef"
@@ -776,8 +785,8 @@ const mainContentContainer = ref<HTMLElement | null>(null)
               v-bind="{
                 ...qrCodeProps,
                 data: data?.length > 0 ? data : t('Have nice day!'),
-                width: 200,
-                height: 200
+                width: PREVIEW_QRCODE_DIM_UNIT,
+                height: PREVIEW_QRCODE_DIM_UNIT
               }"
               role="img"
               aria-label="QR code"

--- a/src/components/QRCodeCreate.vue
+++ b/src/components/QRCodeCreate.vue
@@ -78,29 +78,15 @@ const lastBackground = ref(defaultPreset.style.background)
 const DEFAULT_FRAME_TEXT = 'Scan for more info'
 const frameText = ref(DEFAULT_FRAME_TEXT)
 const frameTextPosition = ref<'top' | 'bottom' | 'left' | 'right'>('bottom')
-const showFrame = ref(true)
+const showFrame = ref(false)
 const frameStyle = ref({
   textColor: '#000000',
-  backgroundColor: 'transparent',
-  borderColor: '',
+  backgroundColor: '#ffffff',
+  borderColor: '#000000',
   borderWidth: '1px',
   borderRadius: '8px',
   padding: '16px'
 })
-
-function resetFrameTemplate() {
-  frameText.value = DEFAULT_FRAME_TEXT
-  frameTextPosition.value = 'bottom'
-  showFrame.value = true
-  frameStyle.value = {
-    textColor: '#000000',
-    backgroundColor: 'transparent',
-    borderColor: '',
-    borderWidth: '1px',
-    borderRadius: '8px',
-    padding: '16px'
-  }
-}
 
 const includeBackground = ref(true)
 watch(
@@ -739,64 +725,64 @@ const mainContentContainer = ref<HTMLElement | null>(null)
     </Drawer>
     <Teleport to="#main-content-container" v-if="mainContentContainer != null">
       <div id="main-content">
-        <div ref="exportElementRef">
-          <QRCodeFrame
-            v-if="showFrame"
-            :frame-text="frameText"
-            :text-position="frameTextPosition"
-            :frame-style="frameStyle"
-          >
-            <template #qr-code>
-              <div id="qr-code-container" class="grid place-items-center">
-                <div
-                  class="grid place-items-center overflow-hidden"
-                  :style="[
-                    style,
-                    {
-                      width: '200px',
-                      height: '200px'
-                    }
-                  ]"
-                >
-                  <StyledQRCode
-                    v-bind="{
-                      ...qrCodeProps,
-                      data: data?.length > 0 ? data : t('Have nice day!'),
-                      width: 200,
-                      height: 200
-                    }"
-                    role="img"
-                    aria-label="QR code"
-                  />
+        <div id="qr-code-container" class="grid place-items-center">
+          <div v-if="showFrame" ref="exportElementRef" class="w-fit">
+            <QRCodeFrame
+              :frame-text="frameText"
+              :text-position="frameTextPosition"
+              :frame-style="frameStyle"
+            >
+              <template #qr-code>
+                <div id="qr-code-container" class="grid place-items-center">
+                  <div
+                    ref="exportElementRef"
+                    class="grid place-items-center overflow-hidden"
+                    :style="[
+                      style,
+                      {
+                        width: '200px',
+                        height: '200px'
+                      }
+                    ]"
+                  >
+                    <StyledQRCode
+                      v-bind="{
+                        ...qrCodeProps,
+                        data: data?.length > 0 ? data : t('Have nice day!'),
+                        width: 200,
+                        height: 200
+                      }"
+                      role="img"
+                      aria-label="QR code"
+                    />
+                  </div>
                 </div>
-              </div>
-            </template>
-          </QRCodeFrame>
-          <template v-else>
-            <div id="qr-code-container" class="grid place-items-center">
-              <div
-                class="grid place-items-center overflow-hidden"
-                :style="[
-                  style,
-                  {
-                    width: '200px',
-                    height: '200px'
-                  }
-                ]"
-              >
-                <StyledQRCode
-                  v-bind="{
-                    ...qrCodeProps,
-                    data: data?.length > 0 ? data : t('Have nice day!'),
-                    width: 200,
-                    height: 200
-                  }"
-                  role="img"
-                  aria-label="QR code"
-                />
-              </div>
-            </div>
-          </template>
+              </template>
+            </QRCodeFrame>
+          </div>
+          <div
+            v-else
+            class="grid place-items-center overflow-hidden"
+            :style="[
+              style,
+              {
+                width: '200px',
+                height: '200px'
+              }
+            ]"
+            ref="exportElementRef"
+          >
+            <StyledQRCode
+              v-bind="{
+                ...qrCodeProps,
+                data: data?.length > 0 ? data : t('Have nice day!'),
+                width: 200,
+                height: 200
+              }"
+              role="img"
+              aria-label="QR code"
+            />
+          </div>
         </div>
         <div class="mt-4 flex flex-col items-center gap-8">
           <div class="flex flex-col items-center justify-center gap-3">

--- a/src/components/QRCodeCreate.vue
+++ b/src/components/QRCodeCreate.vue
@@ -123,7 +123,7 @@ const qrOptions = computed(() => ({
 }))
 
 const qrCodeProps = computed<StyledQRCodeProps>(() => ({
-  data: data.value,
+  data: data.value || 'Have a beautiful day!',
   image: image.value,
   width: width.value,
   height: height.value,

--- a/src/components/QRCodeCreate.vue
+++ b/src/components/QRCodeCreate.vue
@@ -247,6 +247,12 @@ const recommendedErrorCorrectionLevel = computed<ErrorCorrectionLevel | null>(()
 
 //#region /* export image utils */
 const PREVIEW_QRCODE_DIM_UNIT = 200
+
+/**
+ * Computes the dimensions for QR code export
+ * When frame is enabled (showFrame = true), dimensions are calculated from the actual rendered element
+ * to include the frame's size. Otherwise, uses the configured width and height values.
+ */
 const options = computed(() => {
   if (!showFrame.value) {
     return {
@@ -268,42 +274,26 @@ async function copyQRToClipboard() {
   await copyImageToClipboard(elementToBeExported.value, options.value)
 }
 
-function downloadQRImageAsPng() {
+/**
+ * Downloads QR code in specified format, handling both single and batch exports
+ * @param format The format to download: 'png', 'svg', or 'jpg'
+ */
+function downloadQRImage(format: 'png' | 'svg' | 'jpg') {
   if (exportMode.value === ExportMode.Single) {
-    downloadPngElement(
-      elementToBeExported.value,
-      'qr-code.png',
-      options.value,
-      styledBorderRadiusFormatted.value
-    )
-  } else {
-    generateBatchQRCodes('png')
-  }
-}
+    const formatConfig = {
+      png: { fn: downloadPngElement, filename: 'qr-code.png' },
+      svg: { fn: downloadSvgElement, filename: 'qr-code.svg' },
+      jpg: { fn: downloadJpgElement, filename: 'qr-code.jpg', extraOptions: { bgcolor: 'white' } }
+    }[format]
 
-function downloadQRImageAsSvg() {
-  if (exportMode.value === ExportMode.Single) {
-    downloadSvgElement(
+    formatConfig.fn(
       elementToBeExported.value,
-      'qr-code.svg',
-      options.value,
+      formatConfig.filename,
+      { ...options.value, ...formatConfig.extraOptions },
       styledBorderRadiusFormatted.value
     )
   } else {
-    generateBatchQRCodes('svg')
-  }
-}
-
-function downloadQRImageAsJpg() {
-  if (exportMode.value === ExportMode.Single) {
-    downloadJpgElement(
-      elementToBeExported.value,
-      'qr-code.jpg',
-      { ...options.value, bgcolor: 'white' },
-      styledBorderRadiusFormatted.value
-    )
-  } else {
-    generateBatchQRCodes('jpg')
+    generateBatchQRCodes(format)
   }
 }
 
@@ -878,7 +868,7 @@ const mainContentContainer = ref<HTMLElement | null>(null)
               <button
                 id="download-qr-image-button-png"
                 class="button"
-                @click="downloadQRImageAsPng"
+                @click="() => downloadQRImage('png')"
                 :disabled="isExportButtonDisabled"
                 :title="
                   isExportButtonDisabled
@@ -908,7 +898,7 @@ const mainContentContainer = ref<HTMLElement | null>(null)
               <button
                 id="download-qr-image-button-jpg"
                 class="button"
-                @click="downloadQRImageAsJpg"
+                @click="() => downloadQRImage('jpg')"
                 :disabled="isExportButtonDisabled"
                 :title="
                   isExportButtonDisabled
@@ -938,7 +928,7 @@ const mainContentContainer = ref<HTMLElement | null>(null)
               <button
                 id="download-qr-image-button-svg"
                 class="button"
-                @click="downloadQRImageAsSvg"
+                @click="() => downloadQRImage('svg')"
                 :disabled="isExportButtonDisabled"
                 :title="
                   isExportButtonDisabled

--- a/src/components/QRCodeCreate.vue
+++ b/src/components/QRCodeCreate.vue
@@ -39,7 +39,6 @@ const props = defineProps<{
   initialData?: string
 }>()
 
-const PREVIEW_QRCODE_DIM_UNIT = 200
 const isLarge = useMediaQuery('(min-width: 768px)')
 
 //#region /** locale */
@@ -247,6 +246,7 @@ const recommendedErrorCorrectionLevel = computed<ErrorCorrectionLevel | null>(()
 //#endregion
 
 //#region /* export image utils */
+const PREVIEW_QRCODE_DIM_UNIT = 200
 const options = computed(() => {
   if (!showFrame.value) {
     return {

--- a/src/components/QRCodeCreate.vue
+++ b/src/components/QRCodeCreate.vue
@@ -651,7 +651,9 @@ async function generateBatchQRCodes(format: 'png' | 'svg' | 'jpg') {
 </script>
 
 <template>
-  <div class="flex items-start justify-center gap-4 pb-[180px] md:flex-row md:gap-12 md:pb-0">
+  <div
+    class="flex items-start justify-center gap-4 pb-[180px] md:flex-row md:gap-6 lg:gap-12 lg:pb-0"
+  >
     <!-- Sticky sidebar on large screens -->
     <div
       v-if="isLarge"
@@ -1317,7 +1319,7 @@ async function generateBatchQRCodes(format: 'png' | 'svg' | 'jpg') {
                     </template>
                   </div>
 
-                  <div class="w-full sm:w-1/3 sm:border-l-2 sm:border-gray-300 sm:pl-4">
+                  <div class="w-full sm:border-l-2 sm:border-gray-300 sm:pl-4 lg:w-1/3">
                     <fieldset class="h-full" role="radiogroup" tabindex="0">
                       <div class="flex flex-row items-center gap-2">
                         <legend>{{ t('Error correction level') }}</legend>

--- a/src/components/QRCodeCreate.vue
+++ b/src/components/QRCodeCreate.vue
@@ -35,6 +35,15 @@ import {
   AccordionTrigger
 } from '@/components/ui/accordion'
 
+interface FrameStyle {
+  textColor: string
+  backgroundColor: string
+  borderColor: string
+  borderWidth: string
+  borderRadius: string
+  padding: string
+}
+
 const props = defineProps<{
   initialData?: string
 }>()
@@ -78,7 +87,7 @@ const DEFAULT_FRAME_TEXT = 'Scan for more info'
 const frameText = ref(DEFAULT_FRAME_TEXT)
 const frameTextPosition = ref<'top' | 'bottom' | 'left' | 'right'>('bottom')
 const showFrame = ref(false)
-const frameStyle = ref({
+const frameStyle = ref<FrameStyle>({
   textColor: '#000000',
   backgroundColor: '#ffffff',
   borderColor: '#000000',
@@ -321,7 +330,22 @@ function uploadImage() {
 //#endregion
 
 //#region /* QR Config Utils */
-function createQrConfig() {
+interface QRCodeConfig {
+  props: StyledQRCodeProps & {
+    name?: string
+  }
+  style: {
+    borderRadius: string
+    background?: string
+  }
+  frame?: {
+    text: string
+    position: 'top' | 'bottom' | 'left' | 'right'
+    style: FrameStyle
+  } | null
+}
+
+function createQrConfig(): QRCodeConfig {
   return {
     props: qrCodeProps.value,
     style: style.value,
@@ -354,7 +378,7 @@ function saveQRConfigToLocalStorage() {
 }
 
 function loadQRConfig(jsonString: string, key?: string) {
-  const qrCodeConfig = JSON.parse(jsonString)
+  const qrCodeConfig = JSON.parse(jsonString) as QRCodeConfig
   const qrCodeProps = qrCodeConfig.props
   const qrCodeStyle = qrCodeConfig.style
   const frameConfig = qrCodeConfig.frame
@@ -362,7 +386,7 @@ function loadQRConfig(jsonString: string, key?: string) {
   const preset = {
     ...qrCodeProps,
     style: qrCodeStyle
-  }
+  } as Preset
 
   if (key) {
     preset.name = key
@@ -372,9 +396,8 @@ function loadQRConfig(jsonString: string, key?: string) {
 
   selectedPreset.value = preset
 
-  showFrame.value = !!frameConfig
-
   if (frameConfig) {
+    showFrame.value = true
     frameText.value = frameConfig.text || DEFAULT_FRAME_TEXT
     frameTextPosition.value = frameConfig.position || 'bottom'
     frameStyle.value = {

--- a/src/components/QRCodeCreate.vue
+++ b/src/components/QRCodeCreate.vue
@@ -1013,20 +1013,26 @@ async function generateBatchQRCodes(format: 'png' | 'svg' | 'jpg') {
     </Teleport>
 
     <div id="settings" class="flex w-full grow flex-col items-start gap-8 text-start">
-      <Accordion type="single" collapsible class="w-full" default-value="qr-code-settings">
+      <Accordion
+        type="multiple"
+        collapsible
+        class="flex w-full flex-col gap-4"
+        default-value="qr-code-settings"
+      >
         <AccordionItem value="frame-settings">
-          <AccordionTrigger class="text-2xl font-semibold text-gray-700 dark:text-gray-100"
+          <AccordionTrigger
+            class="button !px-4 text-2xl text-gray-700 outline-none dark:text-gray-100 md:!px-6 lg:!px-8"
             ><span class="flex flex-row items-center gap-2"
               ><span>{{ t('Frame settings') }}</span>
               <span
-                class="rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-800 dark:bg-zinc-700 dark:text-zinc-200"
+                class="rounded-full bg-white px-2 py-0.5 text-xs font-medium text-zinc-800 dark:bg-zinc-700 dark:text-zinc-200"
               >
                 {{ t('New!') }}
               </span></span
             ></AccordionTrigger
           >
-          <AccordionContent>
-            <div class="space-y-4 pt-4">
+          <AccordionContent class="px-2 pb-8 pt-4">
+            <div class="space-y-4">
               <div class="flex flex-row items-center gap-2">
                 <label for="show-frame">{{ t('Add frame') }}</label>
                 <input id="show-frame" type="checkbox" class="checkbox" v-model="showFrame" />
@@ -1141,11 +1147,12 @@ async function generateBatchQRCodes(format: 'png' | 'svg' | 'jpg') {
           </AccordionContent>
         </AccordionItem>
         <AccordionItem value="qr-code-settings">
-          <AccordionTrigger class="text-2xl font-semibold text-gray-700 dark:text-gray-100">{{
-            t('QR Code settings')
-          }}</AccordionTrigger>
-          <AccordionContent>
-            <div class="space-y-8 pt-4">
+          <AccordionTrigger
+            class="button !px-4 text-2xl text-gray-700 outline-none dark:text-gray-100 md:!px-6 lg:!px-8"
+            >{{ t('QR Code settings') }}</AccordionTrigger
+          >
+          <AccordionContent class="px-2 pb-8 pt-4">
+            <div class="space-y-8">
               <div>
                 <label>{{ t('Preset') }}</label>
                 <div class="flex flex-row items-center justify-start gap-2">
@@ -1157,7 +1164,7 @@ async function generateBatchQRCodes(format: 'png' | 'svg' | 'jpg') {
                     :insert-divider-at-indexes="[0, 2]"
                   />
                   <button
-                    class="icon-button"
+                    class="button"
                     @click="randomizeStyleSettings"
                     :aria-label="t('Randomize style')"
                   >

--- a/src/components/QRCodeCreate.vue
+++ b/src/components/QRCodeCreate.vue
@@ -1017,7 +1017,7 @@ async function generateBatchQRCodes(format: 'png' | 'svg' | 'jpg') {
         type="multiple"
         collapsible
         class="flex w-full flex-col gap-4"
-        default-value="qr-code-settings"
+        :default-value="['qr-code-settings']"
       >
         <AccordionItem value="frame-settings">
           <AccordionTrigger
@@ -1264,7 +1264,7 @@ async function generateBatchQRCodes(format: 'png' | 'svg' | 'jpg') {
                           <a
                             href="/6_strings_batch.csv"
                             download
-                            class="inline-flex items-center gap-1 text-sm text-zinc-500 hover:text-zinc-700 hover:underline dark:text-zinc-400 dark:hover:text-zinc-200"
+                            class="inline-flex items-center gap-1 text-sm text-zinc-500 outline-none hover:text-zinc-700 hover:underline focus-visible:ring-1 focus-visible:ring-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200 dark:focus-visible:ring-zinc-200"
                           >
                             {{ t('Example file') }}
                             <svg

--- a/src/components/QRCodeCreate.vue
+++ b/src/components/QRCodeCreate.vue
@@ -666,8 +666,13 @@ async function generateBatchQRCodes(format: 'png' | 'svg' | 'jpg') {
         <div class="flex flex-col items-center">
           <!-- Handle indicator for bottom sheet -->
           <div class="mt-2 h-1 w-16 rounded-full bg-gray-300 dark:bg-gray-700"></div>
-          <div class="w-full p-4">
-            <div class="grid place-items-center">
+          <div
+            :class="[
+              'w-full',
+              showFrame && ['left', 'right'].includes(frameTextPosition) ? '-my-4' : '-my-8'
+            ]"
+          >
+            <div class="flex origin-center scale-[0.7] items-center justify-center md:scale-100">
               <QRCodeFrame
                 v-if="showFrame"
                 :frame-text="frameText"
@@ -675,16 +680,15 @@ async function generateBatchQRCodes(format: 'png' | 'svg' | 'jpg') {
                 :frame-style="frameStyle"
               >
                 <template #qr-code>
-                  <div class="grid place-items-center">
+                  <div id="qr-code-container" class="grid place-items-center">
                     <div
+                      id="element-to-export"
                       class="grid place-items-center overflow-hidden"
                       :style="[
                         style,
                         {
-                          width: '120px',
-                          height: '120px',
-                          maxWidth: '100%',
-                          maxHeight: '100%'
+                          width: `${PREVIEW_QRCODE_DIM_UNIT}px`,
+                          height: `${PREVIEW_QRCODE_DIM_UNIT}px`
                         }
                       ]"
                     >
@@ -692,11 +696,11 @@ async function generateBatchQRCodes(format: 'png' | 'svg' | 'jpg') {
                         v-bind="{
                           ...qrCodeProps,
                           data: data?.length > 0 ? data : t('Have nice day!'),
-                          width: 120,
-                          height: 120
+                          width: PREVIEW_QRCODE_DIM_UNIT,
+                          height: PREVIEW_QRCODE_DIM_UNIT
                         }"
                         role="img"
-                        aria-label="QR code preview"
+                        aria-label="QR code"
                       />
                     </div>
                   </div>
@@ -709,10 +713,8 @@ async function generateBatchQRCodes(format: 'png' | 'svg' | 'jpg') {
                     :style="[
                       style,
                       {
-                        width: '120px',
-                        height: '120px',
-                        maxWidth: '100%',
-                        maxHeight: '100%'
+                        width: `${PREVIEW_QRCODE_DIM_UNIT}px`,
+                        height: `${PREVIEW_QRCODE_DIM_UNIT}px`
                       }
                     ]"
                   >
@@ -720,8 +722,8 @@ async function generateBatchQRCodes(format: 'png' | 'svg' | 'jpg') {
                       v-bind="{
                         ...qrCodeProps,
                         data: data?.length > 0 ? data : t('Have nice day!'),
-                        width: 120,
-                        height: 120
+                        width: PREVIEW_QRCODE_DIM_UNIT,
+                        height: PREVIEW_QRCODE_DIM_UNIT
                       }"
                       role="img"
                       aria-label="QR code preview"
@@ -765,7 +767,13 @@ async function generateBatchQRCodes(format: 'png' | 'svg' | 'jpg') {
     </Drawer>
     <Teleport to="#main-content-container" v-if="mainContentContainer != null">
       <div id="main-content">
-        <div id="qr-code-container" class="grid place-items-center">
+        <div
+          id="qr-code-container"
+          :class="[
+            'grid origin-center place-items-center',
+            showFrame && ['left', 'right'].includes(frameTextPosition) && 'scale-[0.7] md:scale-100'
+          ]"
+        >
           <div v-if="showFrame" id="element-to-export">
             <QRCodeFrame
               :frame-text="frameText"

--- a/src/components/QRCodeCreate.vue
+++ b/src/components/QRCodeCreate.vue
@@ -1,6 +1,12 @@
 <script setup lang="ts">
-import StyledQRCode from '@/components/StyledQRCode.vue'
 import QRCodeFrame from '@/components/QRCodeFrame.vue'
+import StyledQRCode from '@/components/StyledQRCode.vue'
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger
+} from '@/components/ui/accordion'
 import { Combobox } from '@/components/ui/Combobox'
 import { Drawer, DrawerContent, DrawerTitle, DrawerTrigger } from '@/components/ui/drawer'
 import { createRandomColor, getRandomItemInArray } from '@/utils/color'
@@ -28,12 +34,6 @@ import {
 import { computed, onMounted, ref, watch } from 'vue'
 import 'vue-i18n'
 import { useI18n } from 'vue-i18n'
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger
-} from '@/components/ui/accordion'
 
 interface FrameStyle {
   textColor: string
@@ -216,6 +216,8 @@ watch(selectedPreset, () => {
     selectedPreset.value.qrOptions && selectedPreset.value.qrOptions.errorCorrectionLevel
       ? selectedPreset.value.qrOptions.errorCorrectionLevel
       : 'Q'
+  // Most presets don't have a frame, so we set it to false by default
+  showFrame.value = false
 })
 
 const LAST_LOADED_LOCALLY_PRESET_KEY = 'Last saved locally'
@@ -296,16 +298,23 @@ const PREVIEW_QRCODE_DIM_UNIT = 200
  * to include the frame's size. Otherwise, uses the configured width and height values.
  */
 const options = computed(() => {
-  if (!showFrame.value) {
+  if (showFrame.value) {
+    console.debug(
+      `=== ~ options ~ elementToBeExported.value.offsetWidth:`,
+      elementToBeExported.value.offsetWidth
+    )
+    console.debug(
+      `=== ~ options ~ (elementToBeExported.value.offsetWidth / PREVIEW_QRCODE_DIM_UNIT) * width.value:`,
+      (elementToBeExported.value.offsetWidth / PREVIEW_QRCODE_DIM_UNIT) * width.value
+    )
     return {
-      width: width.value,
-      height: height.value
+      width: (elementToBeExported.value.offsetWidth / PREVIEW_QRCODE_DIM_UNIT) * width.value,
+      height: (elementToBeExported.value.offsetHeight / PREVIEW_QRCODE_DIM_UNIT) * height.value
     }
   }
-
   return {
-    width: (elementToBeExported.value.offsetWidth / PREVIEW_QRCODE_DIM_UNIT) * width.value,
-    height: (elementToBeExported.value.offsetHeight / PREVIEW_QRCODE_DIM_UNIT) * height.value
+    width: width.value,
+    height: height.value
   }
 })
 

--- a/src/components/QRCodeFrame.vue
+++ b/src/components/QRCodeFrame.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+interface FrameStyle {
+  textColor?: string
+  backgroundColor?: string
+  borderColor?: string
+  borderWidth?: string
+  borderRadius?: string
+  padding?: string
+}
+
+interface Props {
+  frameText: string
+  textPosition: 'top' | 'bottom' | 'left' | 'right'
+  frameStyle?: FrameStyle
+}
+
+withDefaults(defineProps<Props>(), {
+  textPosition: 'bottom',
+  frameStyle: () => ({})
+})
+</script>
+
+<template>
+  <div class="flex w-full items-center justify-center">
+    <div
+      class="w-fit"
+      :class="[
+        textPosition === 'left' || textPosition === 'right' ? 'flex-row' : 'flex-col',
+        {
+          'flex-row-reverse': textPosition === 'left',
+          'flex-col-reverse': textPosition === 'top'
+        }
+      ]"
+      :style="{
+        backgroundColor: frameStyle.backgroundColor,
+        borderColor: frameStyle.borderColor,
+        borderWidth: frameStyle.borderWidth,
+        borderRadius: frameStyle.borderRadius,
+        padding: frameStyle.padding,
+        borderStyle: frameStyle.borderColor ? 'solid' : 'none',
+        gap: '1rem',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center'
+      }"
+    >
+      <slot name="qr-code"></slot>
+      <p
+        :style="{
+          color: frameStyle.textColor,
+          margin: 0,
+          textAlign: 'center',
+          [textPosition === 'left' || textPosition === 'right' ? 'width' : 'maxWidth']: '200px'
+        }"
+      >
+        {{ frameText }}
+      </p>
+    </div>
+  </div>
+</template>

--- a/src/components/QRCodeFrame.vue
+++ b/src/components/QRCodeFrame.vue
@@ -21,40 +21,38 @@ withDefaults(defineProps<Props>(), {
 </script>
 
 <template>
-  <div class="flex w-full items-center justify-center">
-    <div
-      class="w-fit"
-      :class="[
-        textPosition === 'left' || textPosition === 'right' ? 'flex-row' : 'flex-col',
-        {
-          'flex-row-reverse': textPosition === 'left',
-          'flex-col-reverse': textPosition === 'top'
-        }
-      ]"
+  <div
+    :class="[
+      'w-fit',
+      textPosition === 'left' || textPosition === 'right' ? 'flex-row' : 'flex-col',
+      {
+        'flex-row-reverse': textPosition === 'left',
+        'flex-col-reverse': textPosition === 'top'
+      }
+    ]"
+    :style="{
+      backgroundColor: frameStyle.backgroundColor,
+      borderColor: frameStyle.borderColor,
+      borderWidth: frameStyle.borderWidth,
+      borderRadius: frameStyle.borderRadius,
+      padding: frameStyle.padding,
+      borderStyle: frameStyle.borderColor ? 'solid' : 'none',
+      gap: '1rem',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center'
+    }"
+  >
+    <slot name="qr-code"></slot>
+    <p
       :style="{
-        backgroundColor: frameStyle.backgroundColor,
-        borderColor: frameStyle.borderColor,
-        borderWidth: frameStyle.borderWidth,
-        borderRadius: frameStyle.borderRadius,
-        padding: frameStyle.padding,
-        borderStyle: frameStyle.borderColor ? 'solid' : 'none',
-        gap: '1rem',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center'
+        color: frameStyle.textColor,
+        margin: 0,
+        textAlign: 'center',
+        [textPosition === 'left' || textPosition === 'right' ? 'width' : 'maxWidth']: '200px'
       }"
     >
-      <slot name="qr-code"></slot>
-      <p
-        :style="{
-          color: frameStyle.textColor,
-          margin: 0,
-          textAlign: 'center',
-          [textPosition === 'left' || textPosition === 'right' ? 'width' : 'maxWidth']: '200px'
-        }"
-      >
-        {{ frameText }}
-      </p>
-    </div>
+      {{ frameText }}
+    </p>
   </div>
 </template>

--- a/src/components/QRCodeScan.vue
+++ b/src/components/QRCodeScan.vue
@@ -362,6 +362,7 @@ defineExpose({
 
           <button
             :class="[
+              'outline-none focus-visible:ring-1 focus-visible:ring-zinc-700 dark:focus-visible:ring-zinc-200',
               'flex w-full cursor-pointer items-center justify-center rounded-lg border-2 border-dashed p-4 py-6 text-center transition-colors',
               isDraggingOver
                 ? 'border-blue-400 bg-blue-50 dark:border-blue-600 dark:bg-blue-900/20'
@@ -407,7 +408,7 @@ defineExpose({
           <div class="mt-4 flex flex-col items-center gap-2">
             <p class="mb-2">{{ t('or') }}</p>
             <button
-              class="z-40 flex items-center gap-2 rounded-lg bg-zinc-100 px-4 py-2 transition-colors hover:bg-zinc-200 dark:bg-zinc-800 dark:hover:bg-zinc-700"
+              class="z-40 flex items-center gap-2 rounded-lg bg-zinc-100 px-4 py-2 outline-none transition-colors hover:bg-zinc-200 focus-visible:ring-1 focus-visible:ring-zinc-700 dark:bg-zinc-800 dark:hover:bg-zinc-700 dark:focus-visible:ring-zinc-200"
               @click="startCameraScanning"
               type="button"
             >

--- a/src/components/ui/accordion/Accordion.vue
+++ b/src/components/ui/accordion/Accordion.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import {
+  AccordionRoot,
+  type AccordionRootEmits,
+  type AccordionRootProps,
+  useForwardPropsEmits
+} from 'reka-ui'
+
+const props = defineProps<AccordionRootProps>()
+const emits = defineEmits<AccordionRootEmits>()
+
+const forwarded = useForwardPropsEmits(props, emits)
+</script>
+
+<template>
+  <AccordionRoot v-bind="forwarded">
+    <slot />
+  </AccordionRoot>
+</template>

--- a/src/components/ui/accordion/AccordionContent.vue
+++ b/src/components/ui/accordion/AccordionContent.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import { cn } from '@/lib/utils'
+import { AccordionContent, type AccordionContentProps } from 'reka-ui'
+import { computed, type HTMLAttributes } from 'vue'
+
+const props = defineProps<AccordionContentProps & { class?: HTMLAttributes['class'] }>()
+
+const delegatedProps = computed(() => {
+  const { class: _, ...delegated } = props
+
+  return delegated
+})
+</script>
+
+<template>
+  <AccordionContent
+    v-bind="delegatedProps"
+    class="overflow-hidden text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+  >
+    <div :class="cn('pb-4 pt-0', props.class)">
+      <slot />
+    </div>
+  </AccordionContent>
+</template>

--- a/src/components/ui/accordion/AccordionItem.vue
+++ b/src/components/ui/accordion/AccordionItem.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import { cn } from '@/lib/utils'
+import { AccordionItem, type AccordionItemProps, useForwardProps } from 'reka-ui'
+import { computed, type HTMLAttributes } from 'vue'
+
+const props = defineProps<AccordionItemProps & { class?: HTMLAttributes['class'] }>()
+
+const delegatedProps = computed(() => {
+  const { class: _, ...delegated } = props
+
+  return delegated
+})
+
+const forwardedProps = useForwardProps(delegatedProps)
+</script>
+
+<template>
+  <AccordionItem v-bind="forwardedProps" :class="cn('border-b', props.class)">
+    <slot />
+  </AccordionItem>
+</template>

--- a/src/components/ui/accordion/AccordionItem.vue
+++ b/src/components/ui/accordion/AccordionItem.vue
@@ -15,7 +15,7 @@ const forwardedProps = useForwardProps(delegatedProps)
 </script>
 
 <template>
-  <AccordionItem v-bind="forwardedProps" :class="cn('border-b', props.class)">
+  <AccordionItem v-bind="forwardedProps" :class="cn(props.class)">
     <slot />
   </AccordionItem>
 </template>

--- a/src/components/ui/accordion/AccordionTrigger.vue
+++ b/src/components/ui/accordion/AccordionTrigger.vue
@@ -19,7 +19,7 @@ const delegatedProps = computed(() => {
       v-bind="delegatedProps"
       :class="
         cn(
-          'flex flex-1 items-center justify-between py-4 text-sm font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180',
+          'flex flex-1 items-center justify-between py-4 text-sm font-medium transition-all [&[data-state=open]>svg]:rotate-180',
           props.class
         )
       "

--- a/src/components/ui/accordion/AccordionTrigger.vue
+++ b/src/components/ui/accordion/AccordionTrigger.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { cn } from '@/lib/utils'
+import { ChevronDown } from 'lucide-vue-next'
+import { AccordionHeader, AccordionTrigger, type AccordionTriggerProps } from 'reka-ui'
+import { computed, type HTMLAttributes } from 'vue'
+
+const props = defineProps<AccordionTriggerProps & { class?: HTMLAttributes['class'] }>()
+
+const delegatedProps = computed(() => {
+  const { class: _, ...delegated } = props
+
+  return delegated
+})
+</script>
+
+<template>
+  <AccordionHeader class="flex">
+    <AccordionTrigger
+      v-bind="delegatedProps"
+      :class="
+        cn(
+          'flex flex-1 items-center justify-between py-4 text-sm font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180',
+          props.class
+        )
+      "
+    >
+      <slot />
+      <slot name="icon">
+        <ChevronDown
+          class="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200"
+        />
+      </slot>
+    </AccordionTrigger>
+  </AccordionHeader>
+</template>

--- a/src/components/ui/accordion/index.ts
+++ b/src/components/ui/accordion/index.ts
@@ -1,0 +1,4 @@
+export { default as Accordion } from './Accordion.vue'
+export { default as AccordionContent } from './AccordionContent.vue'
+export { default as AccordionItem } from './AccordionItem.vue'
+export { default as AccordionTrigger } from './AccordionTrigger.vue'

--- a/src/utils/convertToImage.ts
+++ b/src/utils/convertToImage.ts
@@ -60,7 +60,23 @@ export async function copyImageToClipboard(
 
 export async function getPngElement(element: HTMLElement, options: Options, borderRadius?: string) {
   const formattedOptions = getFormattedOptions(element, options, borderRadius)
-  return domtoimage.toPng(element, formattedOptions)
+  return new Promise<string>((resolve, reject) => {
+    domtoimage
+      .toBlob(element, formattedOptions)
+      .then((blob: Blob) => {
+        const reader = new FileReader()
+        reader.onloadend = () => {
+          if (typeof reader.result === 'string') {
+            resolve(reader.result)
+          } else {
+            reject(new Error('Failed to convert blob to data URL'))
+          }
+        }
+        reader.onerror = () => reject(reader.error)
+        reader.readAsDataURL(blob)
+      })
+      .catch(reject)
+  })
 }
 
 export function downloadPngElement(


### PR DESCRIPTION
# Add QR Code Frame Feature

This PR adds a new feature that allows users to add a customizable frame around QR codes with text. The frame can be positioned at the top, bottom, left, or right of the QR code with customizable styling options.

## Features

- Add new `QRCodeFrame` component for displaying QR codes with a customizable frame
- Implement frame text customization with options for text content and position
- Add frame style customization including text color, background color, border color, width, radius, and padding
- Organize QR code settings into collapsible accordion sections for better UX
- Update QR code export functionality to properly handle frames
- Add frame configuration to QR code save/load functionality
- Implement responsive design for frame display in different screen sizes

## Technical Changes

- Create new `QRCodeFrame.vue` component for frame rendering
- Add accordion UI components for better organization of settings
- Update QR code generation and export logic to support frames
- Improve image export functionality to handle framed QR codes
- Enhance configuration save/load to include frame settings

The frame feature provides users with more customization options and improves the visual presentation of QR codes for various use cases.