### PR TITLE
Add camera switching feature to QR code scanner

### DIFF
--- a/src/components/QRCodeCameraScanner.vue
+++ b/src/components/QRCodeCameraScanner.vue
@@ -42,6 +42,8 @@ const startScanning = async () => {
       return
     }
 
+    hasMultipleCameras.value = devices && devices.length > 1
+
     // Select camera based on internal state and availability
     const preferredType = isFrontCamera.value ? 'front' : 'back'
 

--- a/src/components/QRCodeCameraScanner.vue
+++ b/src/components/QRCodeCameraScanner.vue
@@ -29,6 +29,11 @@ const startScanning = async () => {
   errorMessage.value = null
   isLoading.value = true
 
+  // Stop scanning if already running
+  if (isScanning.value) {
+    await stopScanning()
+  }
+
   try {
     if (!html5QrCodeScanner.value) {
       html5QrCodeScanner.value = new Html5Qrcode(scannerContainerId)
@@ -70,11 +75,6 @@ const startScanning = async () => {
         firstCameraLabel.includes('selfie')
       isFrontCamera.value = isFront
       localStorage.setItem(CAMERA_PREFERENCE_KEY, isFront ? 'front' : 'back')
-    }
-
-    // Stop scanning if already running
-    if (isScanning.value) {
-      await stopScanning()
     }
 
     await html5QrCodeScanner.value!.start(

--- a/src/components/QRCodeCameraScanner.vue
+++ b/src/components/QRCodeCameraScanner.vue
@@ -31,7 +31,18 @@ const startScanning = async () => {
 
   // Stop scanning if already running
   if (isScanning.value) {
-    await stopScanning()
+    if (html5QrCodeScanner.value && isScanning.value) {
+      try {
+        // Check if scanner is in scanning state before stopping
+        if (html5QrCodeScanner.value.getState() === Html5QrcodeScannerState.SCANNING) {
+          await html5QrCodeScanner.value.stop()
+        }
+      } catch (err) {
+        console.error('Error stopping QR scanner:', err)
+      } finally {
+        isScanning.value = false
+      }
+    }
   }
 
   try {


### PR DESCRIPTION
# Add Camera Switching Functionality to QR Code Scanner

Resolves #102 

This PR enhances the QR code scanner component by adding the ability to switch between front and rear cameras. The improvements include:

- Added a camera toggle button that appears when multiple cameras are detected
- Implemented logic to detect front/rear cameras based on device labels
- Added state management for tracking which camera is currently active
- Improved camera detection to determine if multiple cameras are available
- Added proper button styling with hover effects and accessibility attributes
- Ensured the scanner stops before switching cameras to prevent conflicts
- Organized scanner controls into a flex container for better layout

The UI now provides a more intuitive experience for users who need to switch between cameras when scanning QR codes.