### PR TITLE
Disable PWA in development mode

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -69,7 +69,7 @@ export default defineConfig({
         navigateFallback: 'index.html'
       },
       devOptions: {
-        enabled: true,
+        // enabled: true,
         type: 'module'
       }
     })


### PR DESCRIPTION
Disabled service worker in development mode by commenting out the `enabled: true` option in the PWA plugin configuration. This prevents the service worker from running during local development while preserving the module type setting.