### PR TITLE
Fix vCard address formatting and add tests

### DIFF
--- a/src/utils/dataEncoding.test.ts
+++ b/src/utils/dataEncoding.test.ts
@@ -158,6 +158,76 @@ describe('Data Encoding Functions', () => {
     expect(resultStringDates).toContain('DTEND:20241225T220000Z')
     expect(generateEventData({})).toContain('BEGIN:VCALENDAR')
   })
+
+  it('generateVCardData formats full address correctly for vCard 3.0', () => {
+    const data = {
+      firstName: 'Jane',
+      lastName: 'Smith',
+      street: '123 Main St',
+      city: 'Anytown',
+      state: 'CA',
+      zipcode: '90210',
+      country: 'USA'
+    }
+    const expectedVCard = `BEGIN:VCARD
+VERSION:3.0
+N:Smith;Jane;;;
+FN:Jane Smith
+ADR;TYPE=WORK:;;123 Main St;Anytown;CA;90210;USA
+END:VCARD`
+    expect(generateVCardData(data)).toBe(expectedVCard)
+  })
+
+  it('generateVCardData formats partial address correctly for vCard 2.1', () => {
+    const data = {
+      firstName: 'Jane',
+      lastName: 'Smith',
+      city: 'Othertown',
+      country: 'Canada',
+      version: '2'
+    }
+    const expectedVCard = `BEGIN:VCARD
+VERSION:2.1
+N:Smith;Jane;;;
+FN:Jane Smith
+ADR;WORK:;;;Othertown;;;Canada
+END:VCARD`
+    expect(generateVCardData(data)).toBe(expectedVCard)
+  })
+
+  it('generateVCardData formats address correctly for vCard 4.0', () => {
+    const data = {
+      firstName: 'Jane',
+      lastName: 'Smith',
+      street: '456 Side St',
+      city: 'Metropolis',
+      zipcode: '12345',
+      version: '4'
+    }
+    const expectedVCard = `BEGIN:VCARD
+VERSION:4.0
+N:Smith;Jane;;;
+FN:Jane Smith
+ADR;TYPE=work:;;456 Side St;Metropolis;;12345;
+END:VCARD`
+    expect(generateVCardData(data)).toBe(expectedVCard)
+  })
+
+  it('generateVCardData omits ADR field when no address parts are provided', () => {
+    const data = {
+      firstName: 'Jane',
+      lastName: 'Smith',
+      email: 'jane@test.com'
+      // No address fields
+    }
+    const expectedVCard = `BEGIN:VCARD
+VERSION:3.0
+N:Smith;Jane;;;
+FN:Jane Smith
+EMAIL:jane@test.com
+END:VCARD`
+    expect(generateVCardData(data)).toBe(expectedVCard)
+  })
 })
 
 describe('Data Type Detection Functions', () => {

--- a/src/utils/dataEncoding.ts
+++ b/src/utils/dataEncoding.ts
@@ -249,23 +249,22 @@ export const generateVCardData = (data: {
     }
   }
 
-  const adrParts = [
-    '',
-    '', // PO Box, Extended Addr
-    escapeVCard(data.street || ''),
-    escapeVCard(data.city || ''),
-    escapeVCard(data.state || ''),
-    escapeVCard(data.zipcode || ''),
-    escapeVCard(data.country || '')
-  ]
+  const street = escapeVCard(data.street || '')
+  const city = escapeVCard(data.city || '')
+  const state = escapeVCard(data.state || '')
+  const zipcode = escapeVCard(data.zipcode || '')
+  const country = escapeVCard(data.country || '')
+  const addressComponents = [street, city, state, zipcode, country]
 
-  if (adrParts.some((part) => part !== '')) {
+  // Only add ADR if at least one address component is present
+  if (addressComponents.some((part) => part !== '')) {
+    const adrString = `${street};${city};${state};${zipcode};${country}` // Construct the address parts string
     if (version === '2') {
-      lines.push(`ADR;WORK:;;${adrParts.join(';')}`)
+      lines.push(`ADR;WORK:;;${adrString}`)
     } else if (version === '4') {
-      lines.push(`ADR;TYPE=work:;;${adrParts.join(';')}`)
+      lines.push(`ADR;TYPE=work:;;${adrString}`)
     } else {
-      lines.push(`ADR;TYPE=WORK:;;${adrParts.join(';')}`)
+      lines.push(`ADR;TYPE=WORK:;;${adrString}`)
     }
   }
 


### PR DESCRIPTION
# Improved vCard Address Formatting

This PR enhances the vCard address formatting in the `generateVCardData` function to properly handle different vCard versions (2.1, 3.0, and 4.0). The changes include:

- Refactored address component handling for better readability
- Added logic to only include the ADR field when at least one address component is present
- Simplified address string construction
- Added comprehensive test cases to verify:
  - Full address formatting for vCard 3.0
  - Partial address formatting for vCard 2.1
  - Address formatting for vCard 4.0
  - Proper omission of the ADR field when no address parts are provided

These improvements ensure that vCard data is generated according to the appropriate specifications for each version.