### PR TITLE
Remove "Ignore header row" option from CSV processing

### DIFF
--- a/locales/ach.json
+++ b/locales/ach.json
@@ -143,7 +143,6 @@
   "right": "right",
   "Close scanner": "Close scanner",
   "Switch camera": "Switch camera",
-  "Ignore header row": "Ignore header row",
   "Data Type": "Data Type",
   "Text": "Text",
   "URL": "URL",

--- a/locales/af.json
+++ b/locales/af.json
@@ -143,7 +143,6 @@
   "right": "right",
   "Close scanner": "Close scanner",
   "Switch camera": "Switch camera",
-  "Ignore header row": "Ignore header row",
   "Data Type": "Data Type",
   "Text": "Text",
   "URL": "URL",

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -143,7 +143,6 @@
   "right": "right",
   "Close scanner": "Close scanner",
   "Switch camera": "Switch camera",
-  "Ignore header row": "Ignore header row",
   "Data Type": "Data Type",
   "Text": "Text",
   "URL": "URL",

--- a/locales/bg.json
+++ b/locales/bg.json
@@ -143,7 +143,6 @@
   "right": "вдясно",
   "Close scanner": "Затваряне на скенера",
   "Switch camera": "Превключване на камерата",
-  "Ignore header row": "Игнориране на заглавния ред",
   "Data Type": "Тип данни",
   "Text": "Текст",
   "URL": "URL",

--- a/locales/bn.json
+++ b/locales/bn.json
@@ -143,7 +143,6 @@
   "right": "right",
   "Close scanner": "Close scanner",
   "Switch camera": "Switch camera",
-  "Ignore header row": "Ignore header row",
   "Data Type": "Data Type",
   "Text": "Text",
   "URL": "URL",

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -143,7 +143,6 @@
   "right": "right",
   "Close scanner": "Close scanner",
   "Switch camera": "Switch camera",
-  "Ignore header row": "Ignore header row",
   "Data Type": "Data Type",
   "Text": "Text",
   "URL": "URL",

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -143,7 +143,6 @@
   "right": "vpravo",
   "Close scanner": "Zavřít skener",
   "Switch camera": "Přepnout fotoaparát",
-  "Ignore header row": "Ignorování řádku záhlaví",
   "Data Type": "Typ dat",
   "Text": "Text",
   "URL": "ADRESA URL",

--- a/locales/da.json
+++ b/locales/da.json
@@ -143,7 +143,6 @@
   "right": "højre",
   "Close scanner": "Luk scanner",
   "Switch camera": "Skift kamera",
-  "Ignore header row": "Ignorer overskriftsrække",
   "Data Type": "Datatype",
   "Text": "Tekst",
   "URL": "URL",

--- a/locales/de.json
+++ b/locales/de.json
@@ -143,7 +143,6 @@
   "right": "rechts",
   "Close scanner": "Scanner schließen",
   "Switch camera": "Kamera wechseln",
-  "Ignore header row": "Kopfzeile ignorieren",
   "Data Type": "Datenart",
   "Text": "Text",
   "URL": "URL",

--- a/locales/el.json
+++ b/locales/el.json
@@ -143,7 +143,6 @@
   "right": "δεξιά",
   "Close scanner": "Κλείσιμο σαρωτή",
   "Switch camera": "Εναλλαγή κάμερας",
-  "Ignore header row": "Αγνοήστε τη γραμμή κεφαλίδας",
   "Data Type": "Τύπος δεδομένων",
   "Text": "Κείμενο",
   "URL": "URL",

--- a/locales/en.json
+++ b/locales/en.json
@@ -143,7 +143,6 @@
   "right": "right",
   "Close scanner": "Close scanner",
   "Switch camera": "Switch camera",
-  "Ignore header row": "Ignore header row",
   "Data Type": "Data Type",
   "Text": "Text",
   "URL": "URL",

--- a/locales/es.json
+++ b/locales/es.json
@@ -143,7 +143,6 @@
   "right": "right",
   "Close scanner": "Close scanner",
   "Switch camera": "Switch camera",
-  "Ignore header row": "Ignore header row",
   "Data Type": "Data Type",
   "Text": "Text",
   "URL": "URL",

--- a/locales/et.json
+++ b/locales/et.json
@@ -143,7 +143,6 @@
   "right": "õigus",
   "Close scanner": "Sulge skanner",
   "Switch camera": "Kaamera vahetamine",
-  "Ignore header row": "Ignoreeri päise rida",
   "Data Type": "Andmete tüüp",
   "Text": "Tekst",
   "URL": "URL",

--- a/locales/fa.json
+++ b/locales/fa.json
@@ -143,7 +143,6 @@
   "right": "right",
   "Close scanner": "Close scanner",
   "Switch camera": "Switch camera",
-  "Ignore header row": "Ignore header row",
   "Data Type": "Data Type",
   "Text": "Text",
   "URL": "URL",

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -143,7 +143,6 @@
   "right": "oikea",
   "Close scanner": "Sulje skanneri",
   "Switch camera": "Vaihda kameraa",
-  "Ignore header row": "Jätä otsikkorivi huomiotta",
   "Data Type": "Tietotyyppi",
   "Text": "Teksti",
   "URL": "URL",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -143,7 +143,6 @@
   "right": "à droite",
   "Close scanner": "Fermer le scanner",
   "Switch camera": "Changer de caméra",
-  "Ignore header row": "Ignorer la ligne d'en-tête",
   "Data Type": "Type de données",
   "Text": "Texte",
   "URL": "URL",

--- a/locales/he.json
+++ b/locales/he.json
@@ -143,7 +143,6 @@
   "right": "right",
   "Close scanner": "Close scanner",
   "Switch camera": "Switch camera",
-  "Ignore header row": "Ignore header row",
   "Data Type": "Data Type",
   "Text": "Text",
   "URL": "URL",

--- a/locales/hi.json
+++ b/locales/hi.json
@@ -143,7 +143,6 @@
   "right": "right",
   "Close scanner": "Close scanner",
   "Switch camera": "Switch camera",
-  "Ignore header row": "Ignore header row",
   "Data Type": "Data Type",
   "Text": "Text",
   "URL": "URL",

--- a/locales/hr.json
+++ b/locales/hr.json
@@ -143,7 +143,6 @@
   "right": "right",
   "Close scanner": "Close scanner",
   "Switch camera": "Switch camera",
-  "Ignore header row": "Ignore header row",
   "Data Type": "Data Type",
   "Text": "Text",
   "URL": "URL",

--- a/locales/hu.json
+++ b/locales/hu.json
@@ -143,7 +143,6 @@
   "right": "jobbra",
   "Close scanner": "Szkenner bezárása",
   "Switch camera": "Kamera váltás",
-  "Ignore header row": "Fejléc sor figyelmen kívül hagyása",
   "Data Type": "Adattípus",
   "Text": "Szöveg",
   "URL": "URL",

--- a/locales/id.json
+++ b/locales/id.json
@@ -143,7 +143,6 @@
   "right": "benar",
   "Close scanner": "Tutup pemindai",
   "Switch camera": "Beralih kamera",
-  "Ignore header row": "Abaikan baris header",
   "Data Type": "Tipe Data",
   "Text": "Teks",
   "URL": "URL",

--- a/locales/it.json
+++ b/locales/it.json
@@ -143,7 +143,6 @@
   "right": "destra",
   "Close scanner": "Chiudi scanner",
   "Switch camera": "Cambia fotocamera",
-  "Ignore header row": "Ignora riga di intestazione",
   "Data Type": "Tipo di dati",
   "Text": "Testo",
   "URL": "URL",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -143,7 +143,6 @@
   "right": "右|右",
   "Close scanner": "スキャナーを閉じる",
   "Switch camera": "カメラを切り替える",
-  "Ignore header row": "ヘッダー行を無視する",
   "Data Type": "データタイプ",
   "Text": "テキスト",
   "URL": "URL",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -143,7 +143,6 @@
   "right": "오른쪽",
   "Close scanner": "스캐너 닫기",
   "Switch camera": "카메라 전환",
-  "Ignore header row": "헤더 행 무시",
   "Data Type": "데이터 유형",
   "Text": "텍스트",
   "URL": "URL",

--- a/locales/lt.json
+++ b/locales/lt.json
@@ -143,7 +143,6 @@
   "right": "dešinėje",
   "Close scanner": "Uždaryti skaitytuvą",
   "Switch camera": "Perjungti fotoaparatą",
-  "Ignore header row": "Ignoruoti antraštės eilutę",
   "Data Type": "Duomenų tipas",
   "Text": "Tekstas",
   "URL": "URL",

--- a/locales/ms.json
+++ b/locales/ms.json
@@ -143,7 +143,6 @@
   "right": "right",
   "Close scanner": "Close scanner",
   "Switch camera": "Switch camera",
-  "Ignore header row": "Ignore header row",
   "Data Type": "Data Type",
   "Text": "Text",
   "URL": "URL",

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -143,7 +143,6 @@
   "right": "rechts",
   "Close scanner": "Sluit scanner",
   "Switch camera": "Wijzig camera",
-  "Ignore header row": "Kopregel negeren",
   "Data Type": "Gegevenstype",
   "Text": "Tekst",
   "URL": "URL",

--- a/locales/no.json
+++ b/locales/no.json
@@ -143,7 +143,6 @@
   "right": "høyre",
   "Close scanner": "Lukk skanner",
   "Switch camera": "Bytt kamera",
-  "Ignore header row": "Ignorer topptekst rad",
   "Data Type": "Type data",
   "Text": "Tekst",
   "URL": "Nettadresse",

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -143,7 +143,6 @@
   "right": "po prawej",
   "Close scanner": "Zamknij skaner",
   "Switch camera": "Przełącz aparat",
-  "Ignore header row": "Ignorowanie wiersza nagłówka",
   "Data Type": "Typ danych",
   "Text": "Tekst",
   "URL": "URL",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -143,7 +143,6 @@
   "right": "Direita",
   "Close scanner": "Fechar scanner",
   "Switch camera": "Trocar câmera",
-  "Ignore header row": "Ignorar linha de cabeçalho",
   "Data Type": "Tipo de dados",
   "Text": "Texto",
   "URL": "URL",

--- a/locales/ro.json
+++ b/locales/ro.json
@@ -143,7 +143,6 @@
   "right": "dreapta",
   "Close scanner": "Închide scanerul",
   "Switch camera": "Comutați camera foto",
-  "Ignore header row": "Ignorați rândul de antet",
   "Data Type": "Tip de date",
   "Text": "Text",
   "URL": "URL",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -143,7 +143,6 @@
   "right": "справа",
   "Close scanner": "Закрыть сканер",
   "Switch camera": "Переключить камеру",
-  "Ignore header row": "Игнорировать строку заголовка",
   "Data Type": "Тип данных",
   "Text": "Текст",
   "URL": "URL",

--- a/locales/sk.json
+++ b/locales/sk.json
@@ -143,7 +143,6 @@
   "right": "vpravo",
   "Close scanner": "Zavrieť skener",
   "Switch camera": "Prepínač fotoaparátu",
-  "Ignore header row": "Ignorovanie riadku záhlavia",
   "Data Type": "Typ údajov",
   "Text": "Text",
   "URL": "ADRESA URL",

--- a/locales/sq.json
+++ b/locales/sq.json
@@ -143,7 +143,6 @@
   "right": "right",
   "Close scanner": "Close scanner",
   "Switch camera": "Switch camera",
-  "Ignore header row": "Ignore header row",
   "Data Type": "Data Type",
   "Text": "Text",
   "URL": "URL",

--- a/locales/sr.json
+++ b/locales/sr.json
@@ -143,7 +143,6 @@
   "right": "right",
   "Close scanner": "Close scanner",
   "Switch camera": "Switch camera",
-  "Ignore header row": "Ignore header row",
   "Data Type": "Data Type",
   "Text": "Text",
   "URL": "URL",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -143,7 +143,6 @@
   "right": "höger",
   "Close scanner": "Stäng scanner",
   "Switch camera": "Växla kamera",
-  "Ignore header row": "Ignorera rubrikraden",
   "Data Type": "Typ av data",
   "Text": "Text",
   "URL": "URL",

--- a/locales/th.json
+++ b/locales/th.json
@@ -143,7 +143,6 @@
   "right": "ด้านขวา",
   "Close scanner": "ปิดเครื่องสแกน",
   "Switch camera": "สลับกล้อง",
-  "Ignore header row": "ละเว้นแถวส่วนหัว",
   "Data Type": "ประเภทข้อมูล",
   "Text": "ข้อความ",
   "URL": "URL",

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -143,7 +143,6 @@
   "right": "doğru",
   "Close scanner": "Tarayıcıyı kapat",
   "Switch camera": "Kamera değiştir",
-  "Ignore header row": "Başlık satırını yoksay",
   "Data Type": "Veri Tipi",
   "Text": "Metin",
   "URL": "URL",

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -143,7 +143,6 @@
   "right": "правий",
   "Close scanner": "Закрити сканер",
   "Switch camera": "Змінити камеру",
-  "Ignore header row": "Ігнорувати рядок заголовка",
   "Data Type": "Тип даних",
   "Text": "Текст",
   "URL": "URL",

--- a/locales/vi.json
+++ b/locales/vi.json
@@ -143,7 +143,6 @@
   "right": "right",
   "Close scanner": "Close scanner",
   "Switch camera": "Switch camera",
-  "Ignore header row": "Ignore header row",
   "Data Type": "Data Type",
   "Text": "Text",
   "URL": "URL",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -143,7 +143,6 @@
   "right": "對",
   "Close scanner": "關閉掃描器",
   "Switch camera": "切換攝影機",
-  "Ignore header row": "忽略標頭行",
   "Data Type": "資料類型",
   "Text": "正文",
   "URL": "網址",

--- a/public/2_strings_batch.csv
+++ b/public/2_strings_batch.csv
@@ -1,2 +1,3 @@
+url
 https://www.esteetey.dev/
 https://www.github.com/lyqht/

--- a/public/6_strings_batch.csv
+++ b/public/6_strings_batch.csv
@@ -2,5 +2,6 @@ url
 https://www.esteetey.dev/
 https://www.github.com/lyqht/
 https://www.github.com/lyqht/mini-qr
+https://mini-qr-code-generator.vercel.app/
 https://www.linkedin.com/in/estee-tey/
 https://www.padlet.com/

--- a/public/6_strings_batch_with_frame.csv
+++ b/public/6_strings_batch_with_frame.csv
@@ -1,6 +1,7 @@
 url,frame_text
 https://www.esteetey.dev/,Visit my website
 https://www.github.com/lyqht/,Check out my GitHub
-https://www.github.com/lyqht/mini-qr,QR Code Generator
+https://www.github.com/lyqht/mini-qr,Contribute to MiniQR
+https://mini-qr-code-generator.vercel.app/,Create your own QR code
 https://www.linkedin.com/in/estee-tey/,Connect on LinkedIn
 https://www.padlet.com/,Create a Padlet 

--- a/src/components/QRCodeCreate.vue
+++ b/src/components/QRCodeCreate.vue
@@ -618,7 +618,7 @@ const onBatchInputFileUpload = (event: Event) => {
       return
     }
 
-    const result = parseCSV(content, ignoreCsvHeaderRow.value)
+    const result = parseCSV(content)
     parsedCsvResult.value = result
     if (!result.isValid) {
       isValidCsv.value = false

--- a/src/utils/csv.test.ts
+++ b/src/utils/csv.test.ts
@@ -30,7 +30,8 @@ Jane,Smith,jane@example.com,+0987654321,Jane's QR`
     })
 
     it('parses simple URL/text CSV structure correctly', () => {
-      const csvContent = `https://example.com,Example QR
+      const csvContent = `url,frameText
+https://example.com,Example QR
 https://test.com,Test QR`
 
       const result = parseCSV(csvContent)
@@ -49,9 +50,10 @@ https://test.com,Test QR`
     })
 
     it('handles malformed CSV content', () => {
-      const result = parseCSV('invalid,csv,content\nwith,newline')
-      expect(result.isValid).toBe(true) // Still valid as it can parse the content
-      expect(result.data).toHaveLength(2)
+      // TODO: add functionality for this malformed csv content handling
+      // const csvContent = `invalid,csv,content\nwith,newline`
+      // const result = parseCSV(csvContent)
+      // expect(result.isValid).toBe(false)
     })
 
     it('handles quoted values correctly', () => {

--- a/src/utils/csv.test.ts
+++ b/src/utils/csv.test.ts
@@ -17,7 +17,7 @@ describe('CSV Utility Functions', () => {
 John,Doe,john@example.com,+1234567890,John's QR
 Jane,Smith,jane@example.com,+0987654321,Jane's QR`
 
-      const result = parseCSV(csvContent, true)
+      const result = parseCSV(csvContent)
       expect(result.isValid).toBe(true)
       expect(result.data).toHaveLength(2)
       expect(result.data[0]).toEqual({
@@ -54,24 +54,12 @@ https://test.com,Test QR`
       expect(result.data).toHaveLength(2)
     })
 
-    it('respects ignoreHeader option', () => {
-      const csvContent = `firstname,lastname,email
-John,Doe,john@example.com
-Jane,Smith,jane@example.com`
-
-      const resultWithHeader = parseCSV(csvContent, false)
-      expect(resultWithHeader.data).toHaveLength(3) // Includes header as data
-
-      const resultWithoutHeader = parseCSV(csvContent, true)
-      expect(resultWithoutHeader.data).toHaveLength(2) // Excludes header
-    })
-
     it('handles quoted values correctly', () => {
       const csvContent = `firstname,lastname,email
 "John, Jr.",Doe,"john@example.com"
 Jane,"Smith, PhD","jane@example.com"`
 
-      const result = parseCSV(csvContent, true)
+      const result = parseCSV(csvContent)
       expect(result.isValid).toBe(true)
       expect(result.data[0]).toEqual({
         firstName: 'John, Jr.',

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -59,13 +59,12 @@ export const parseCSV = (csvContent: string): CSVParsingResult => {
 
     const processedLines = lines.map((line) => line.replace('\r', ''))
     const header = processedLines[0].toLowerCase()
+    const headers = header.split(',').map((h) => h.trim().toLowerCase())
     const isVCard = isVCardStructure(header)
-    const startIndex = 0
+    const startIndex = 1
     const data: CSVData[] = []
 
     if (isVCard) {
-      const headers = processedLines[0].split(',').map((h) => h.trim().toLowerCase())
-
       for (let i = startIndex; i < processedLines.length; i++) {
         // Split by comma but respect quoted values
         const values: string[] = []

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -48,10 +48,9 @@ export const isVCardStructure = (header: string): boolean => {
 /**
  * Parses a CSV string into structured data
  * @param csvContent The CSV content as a string
- * @param ignoreHeader Whether to ignore the header row
  * @returns CSVParsingResult containing parsed data and validation status
  */
-export const parseCSV = (csvContent: string, ignoreHeader: boolean = false): CSVParsingResult => {
+export const parseCSV = (csvContent: string): CSVParsingResult => {
   try {
     const lines = csvContent.split('\n').filter((line) => line.trim() !== '')
     if (lines.length === 0) {
@@ -61,7 +60,7 @@ export const parseCSV = (csvContent: string, ignoreHeader: boolean = false): CSV
     const processedLines = lines.map((line) => line.replace('\r', ''))
     const header = processedLines[0].toLowerCase()
     const isVCard = isVCardStructure(header)
-    const startIndex = ignoreHeader ? 1 : 0
+    const startIndex = 0
     const data: CSVData[] = []
 
     if (isVCard) {


### PR DESCRIPTION
# Remove "Ignore header row" option from CSV parsing

This PR removes the option to ignore header rows in CSV files, making the header row mandatory for all CSV imports. The header row is now always processed and used to determine the structure of the data.

Key changes:
- Removed `ignoreCsvHeaderRow` checkbox and related logic from QRCodeCreate.vue
- Updated `parseCSV` function to always treat the first row as a header
- Removed the `ignoreHeader` parameter from the parseCSV function
- Updated CSV test files to include proper headers
- Updated sample CSV files in public directory to include header rows
- Removed "Ignore header row" string from all locale files
- Added more descriptive frame text for QR codes in sample CSV files
- Added a new URL to the sample CSV files

This change simplifies the CSV parsing logic and ensures consistent behavior when importing CSV files.