### PR TITLE
Add multiline support for frame text

### DIFF
--- a/src/components/QRCodeFrame.vue
+++ b/src/components/QRCodeFrame.vue
@@ -44,15 +44,16 @@ withDefaults(defineProps<Props>(), {
     }"
   >
     <slot name="qr-code"></slot>
-    <p
-      :style="{
-        color: frameStyle.textColor,
-        margin: 0,
-        textAlign: 'center',
-        [textPosition === 'left' || textPosition === 'right' ? 'width' : 'maxWidth']: '200px'
-      }"
-    >
-      {{ frameText }}
-    </p>
+      <p
+        :style="{
+          color: frameStyle.textColor,
+          margin: 0,
+          textAlign: 'center',
+          [textPosition === 'left' || textPosition === 'right' ? 'width' : 'maxWidth']: '200px',
+          whiteSpace: 'pre-line'
+        }"
+      >
+        {{ frameText }}
+      </p>
   </div>
 </template>

--- a/tests/e2e/create.spec.ts
+++ b/tests/e2e/create.spec.ts
@@ -188,6 +188,28 @@ test('QR code element with frame matches snapshot', async ({ page }) => {
   await expect(qrCodeExportElement).toHaveScreenshot('qr-code-with-frame-snapshot.png')
 })
 
+test('frame text supports line breaks', async ({ page }) => {
+  const textInput = page.locator('textarea[id="data"]')
+  const frameAccordionTrigger = page.getByRole('button', { name: /Frame settings/ })
+  const showFrameCheckbox = page.locator('input[id="show-frame"]')
+  const frameTextInput = page.locator('textarea[id="frame-text"]')
+
+  // Expand the Frame settings accordion
+  await frameAccordionTrigger.click()
+
+  // Set data, enable frame, and add multiline frame text
+  await textInput.fill('Multiline Frame Test')
+  await showFrameCheckbox.check()
+  const multilineText = 'Line 1\nLine 2\nLine 3'
+  await frameTextInput.fill(multilineText)
+
+  // Locate the paragraph that displays the frame text
+  const frameTextDisplay = page.locator('#element-to-export p')
+
+  // Ensure the displayed text preserves the line breaks
+  await expect(frameTextDisplay).toHaveText(multilineText)
+})
+
 test('QR code element matches snapshot', async ({ page }) => {
   const testData = 'Snapshot Test'
   const textInput = page.locator('textarea[id="data"]')


### PR DESCRIPTION
Resolves #140 

## Summary
- preserve newlines in `QRCodeFrame` text
- test multiline frame text rendering