### PR TITLE
Add frame presets support

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -130,6 +130,7 @@
   "QR code settings": "QR code settings",
   "Add frame": "Add frame",
   "Frame style": "Frame style",
+  "Frame preset": "Frame preset",
   "Text position": "Text position",
   "Scan for more info": "Scan for more info",
   "Text color": "Text color",

--- a/src/utils/framePresets.ts
+++ b/src/utils/framePresets.ts
@@ -1,0 +1,57 @@
+export interface FrameStyle {
+  textColor: string
+  backgroundColor: string
+  borderColor: string
+  borderWidth: string
+  borderRadius: string
+  padding: string
+}
+
+export interface FramePreset {
+  name: string
+  style: FrameStyle
+  text?: string
+  position?: 'top' | 'bottom' | 'left' | 'right'
+}
+
+export const defaultFramePreset: FramePreset = {
+  name: 'Default Frame',
+  style: {
+    textColor: '#000000',
+    backgroundColor: '#ffffff',
+    borderColor: '#000000',
+    borderWidth: '1px',
+    borderRadius: '8px',
+    padding: '16px'
+  }
+}
+
+export const darkFramePreset: FramePreset = {
+  name: 'Dark Frame',
+  style: {
+    textColor: '#ffffff',
+    backgroundColor: '#000000',
+    borderColor: '#ffffff',
+    borderWidth: '1px',
+    borderRadius: '8px',
+    padding: '16px'
+  }
+}
+
+export const borderlessFramePreset: FramePreset = {
+  name: 'Borderless Frame',
+  style: {
+    textColor: '#000000',
+    backgroundColor: '#ffffff',
+    borderColor: '#ffffff',
+    borderWidth: '0px',
+    borderRadius: '0px',
+    padding: '16px'
+  }
+}
+
+export const allFramePresets: FramePreset[] = [
+  defaultFramePreset,
+  darkFramePreset,
+  borderlessFramePreset
+]

--- a/tests/e2e/create.spec.ts
+++ b/tests/e2e/create.spec.ts
@@ -118,6 +118,9 @@ test('save and load QR code config works with frame', async ({ page }) => {
   // Set initial data, enable frame, set text, and change position
   await textInput.fill(testData)
   await showFrameCheckbox.check()
+  const framePresetButton = page.getByLabel('Select preset').first()
+  await framePresetButton.click()
+  await page.getByText('Dark Frame').click()
   await frameTextInput.fill(frameTextData)
   await framePositionTopRadio.check() // Change from default bottom to top
 
@@ -160,6 +163,7 @@ test('save and load QR code config works with frame', async ({ page }) => {
   await expect(showFrameCheckbox).toBeChecked()
   await expect(frameTextInput).toHaveValue(frameTextData)
   await expect(framePositionTopRadio).toBeChecked() // Check if the non-default position was restored
+  await expect(page.locator('#frame-text-color')).toHaveValue('#ffffff')
 })
 
 test('QR code element with frame matches snapshot', async ({ page }) => {


### PR DESCRIPTION
Resolves #146 

## Summary
- add frame presets list and types
- support selecting frame presets in QR code creator
- persist custom frame presets when saving/loading configs
- update localization for new UI text
- test loading configs with frame presets