### PR TITLE
Add frame presets support

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -130,6 +130,7 @@
   "QR code settings": "QR code settings",
   "Add frame": "Add frame",
   "Frame style": "Frame style",
+  "Frame preset": "Frame preset",
   "Text position": "Text position",
   "Scan for more info": "Scan for more info",
   "Text color": "Text color",

--- a/src/components/QRCodeCreate.vue
+++ b/src/components/QRCodeCreate.vue
@@ -27,6 +27,7 @@ import { parseCSV, validateCSVData } from '@/utils/csv'
 import { generateVCardData } from '@/utils/dataEncoding'
 import { getNumericCSSValue } from '@/utils/formatting'
 import { allPresets, type Preset } from '@/utils/presets'
+import { allFramePresets, type FramePreset } from '@/utils/framePresets'
 import { useMediaQuery } from '@vueuse/core'
 import JSZip from 'jszip'
 import {
@@ -287,6 +288,47 @@ const frameStyle = ref<FrameStyle>({
   borderRadius: '8px',
   padding: '16px'
 })
+const defaultFramePreset = allFramePresets[0]
+const selectedFramePresetKey = ref<string>(defaultFramePreset.name)
+const lastCustomLoadedFramePreset = ref<FramePreset>()
+const CUSTOM_LOADED_FRAME_PRESET_KEYS = [
+  LAST_LOADED_LOCALLY_PRESET_KEY,
+  LOADED_FROM_FILE_PRESET_KEY
+]
+const allFramePresetOptions = computed(() => {
+  const options = lastCustomLoadedFramePreset.value
+    ? [lastCustomLoadedFramePreset.value, ...allFramePresets]
+    : allFramePresets
+  return options.map((preset) => ({ value: preset.name, label: t(preset.name) }))
+})
+function applyFramePreset(preset: FramePreset) {
+  if (preset.style) {
+    frameStyle.value = { ...frameStyle.value, ...preset.style }
+  }
+  if (preset.text) frameText.value = preset.text
+  if (preset.position) frameTextPosition.value = preset.position
+  showFrame.value = true
+}
+watch(
+  selectedFramePresetKey,
+  (newKey, prevKey) => {
+    if (newKey === prevKey || !newKey) return
+
+    if (
+      CUSTOM_LOADED_FRAME_PRESET_KEYS.includes(newKey) &&
+      lastCustomLoadedFramePreset.value
+    ) {
+      applyFramePreset(lastCustomLoadedFramePreset.value)
+      return
+    }
+
+    const preset = allFramePresets.find((p) => p.name === newKey)
+    if (preset) {
+      applyFramePreset(preset)
+    }
+  },
+  { immediate: true }
+)
 const frameSettings = computed(() => ({
   text: frameText.value,
   position: frameTextPosition.value,
@@ -468,6 +510,8 @@ function loadQRConfig(jsonString: string, key?: string) {
     selectedPresetKey.value = key
   }
 
+  let framePreset: FramePreset | undefined
+
   selectedPreset.value = preset
 
   if (frameConfig) {
@@ -478,6 +522,17 @@ function loadQRConfig(jsonString: string, key?: string) {
       ...frameStyle.value,
       ...frameConfig.style
     }
+    framePreset = {
+      name: key || LAST_LOADED_LOCALLY_PRESET_KEY,
+      style: frameConfig.style,
+      text: frameConfig.text,
+      position: frameConfig.position
+    }
+  }
+
+  if (framePreset && key) {
+    lastCustomLoadedFramePreset.value = framePreset
+    selectedFramePresetKey.value = key
   }
 }
 
@@ -1174,6 +1229,15 @@ const updateDataFromModal = (newData: string) => {
               <div class="flex flex-row items-center gap-2">
                 <label for="show-frame">{{ t('Add frame') }}</label>
                 <input id="show-frame" type="checkbox" v-model="showFrame" />
+              </div>
+
+              <div v-if="showFrame" class="flex flex-row items-center gap-2">
+                <label>{{ t('Frame preset') }}</label>
+                <Combobox
+                  :items="allFramePresetOptions"
+                  v-model:value="selectedFramePresetKey"
+                  :button-label="t('Select preset')"
+                />
               </div>
 
               <div v-if="showFrame">

--- a/src/utils/framePresets.ts
+++ b/src/utils/framePresets.ts
@@ -1,0 +1,57 @@
+export interface FrameStyle {
+  textColor: string
+  backgroundColor: string
+  borderColor: string
+  borderWidth: string
+  borderRadius: string
+  padding: string
+}
+
+export interface FramePreset {
+  name: string
+  style: FrameStyle
+  text?: string
+  position?: 'top' | 'bottom' | 'left' | 'right'
+}
+
+export const defaultFramePreset: FramePreset = {
+  name: 'Default Frame',
+  style: {
+    textColor: '#000000',
+    backgroundColor: '#ffffff',
+    borderColor: '#000000',
+    borderWidth: '1px',
+    borderRadius: '8px',
+    padding: '16px'
+  }
+}
+
+export const darkFramePreset: FramePreset = {
+  name: 'Dark Frame',
+  style: {
+    textColor: '#ffffff',
+    backgroundColor: '#000000',
+    borderColor: '#ffffff',
+    borderWidth: '1px',
+    borderRadius: '8px',
+    padding: '16px'
+  }
+}
+
+export const borderlessFramePreset: FramePreset = {
+  name: 'Borderless Frame',
+  style: {
+    textColor: '#000000',
+    backgroundColor: '#ffffff',
+    borderColor: '#ffffff',
+    borderWidth: '0px',
+    borderRadius: '0px',
+    padding: '16px'
+  }
+}
+
+export const allFramePresets: FramePreset[] = [
+  defaultFramePreset,
+  darkFramePreset,
+  borderlessFramePreset
+]

--- a/tests/e2e/create.spec.ts
+++ b/tests/e2e/create.spec.ts
@@ -118,6 +118,9 @@ test('save and load QR code config works with frame', async ({ page }) => {
   // Set initial data, enable frame, set text, and change position
   await textInput.fill(testData)
   await showFrameCheckbox.check()
+  const framePresetButton = page.getByLabel('Select preset').first()
+  await framePresetButton.click()
+  await page.getByText('Dark Frame').click()
   await frameTextInput.fill(frameTextData)
   await framePositionTopRadio.check() // Change from default bottom to top
 
@@ -160,6 +163,7 @@ test('save and load QR code config works with frame', async ({ page }) => {
   await expect(showFrameCheckbox).toBeChecked()
   await expect(frameTextInput).toHaveValue(frameTextData)
   await expect(framePositionTopRadio).toBeChecked() // Check if the non-default position was restored
+  await expect(page.locator('#frame-text-color')).toHaveValue('#ffffff')
 })
 
 test('QR code element with frame matches snapshot', async ({ page }) => {


### PR DESCRIPTION
## Summary
- add frame presets list and types
- support selecting frame presets in QR code creator
- persist custom frame presets when saving/loading configs
- update localization for new UI text
- test loading configs with frame presets
- fix frame preset select on reload showing blank value

## Testing
- `pnpm lint` *(fails: node_modules missing)*
- `pnpm vitest` *(fails: vitest not found)*
- `pnpm test:e2e` *(fails: playwright not found)*