### PR TITLE
Improve random style generator

### DIFF
--- a/src/components/QRCodeCreate.vue
+++ b/src/components/QRCodeCreate.vue
@@ -12,7 +12,12 @@ import {
 import { Combobox } from '@/components/ui/Combobox'
 import { Drawer, DrawerContent, DrawerTitle, DrawerTrigger } from '@/components/ui/drawer'
 import VCardPreview from '@/components/VCardPreview.vue'
-import { createRandomColor, getRandomItemInArray } from '@/utils/color'
+import {
+  createRandomColor,
+  getRandomItemInArray,
+  createComplementaryScheme,
+  getAverageImageColor
+} from '@/utils/color'
 import {
   copyImageToClipboard,
   downloadJpgElement,
@@ -156,7 +161,7 @@ const qrCodeProps = computed<StyledQRCodeProps>(() => ({
   qrOptions: qrOptions.value
 }))
 
-function randomizeStyleSettings() {
+async function randomizeStyleSettings() {
   const dotTypes: DotType[] = [
     'dots',
     'rounded',
@@ -169,15 +174,19 @@ function randomizeStyleSettings() {
   const cornerDotTypes: CornerDotType[] = ['dot', 'square']
 
   dotsOptionsType.value = getRandomItemInArray(dotTypes)
-  dotsOptionsColor.value = createRandomColor()
-
   cornersSquareOptionsType.value = getRandomItemInArray(cornerSquareTypes)
-  cornersSquareOptionsColor.value = createRandomColor()
-
   cornersDotOptionsType.value = getRandomItemInArray(cornerDotTypes)
-  cornersDotOptionsColor.value = createRandomColor()
 
-  styleBackground.value = createRandomColor()
+  const baseColor =
+    image.value && typeof window !== 'undefined'
+      ? await getAverageImageColor(image.value)
+      : null
+  const scheme = createComplementaryScheme(baseColor || createRandomColor())
+
+  dotsOptionsColor.value = scheme.primary
+  cornersSquareOptionsColor.value = scheme.secondary
+  cornersDotOptionsColor.value = scheme.accent
+  styleBackground.value = scheme.background
 }
 
 function uploadImage() {

--- a/src/utils/color.test.ts
+++ b/src/utils/color.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { hexToHsl, hslToHex, createComplementaryScheme } from './color'
+
+describe('color utilities', () => {
+  it('converts hex to hsl and back', () => {
+    const hex = '#336699'
+    const { h, s, l } = hexToHsl(hex)
+    const converted = hslToHex(h, s, l)
+    expect(converted.toLowerCase()).toBe(hex)
+  })
+
+  it('creates a complementary color scheme', () => {
+    const scheme = createComplementaryScheme('#123456')
+    expect(Object.keys(scheme)).toHaveLength(4)
+  })
+})

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -5,3 +5,125 @@ export function createRandomColor() {
 export function getRandomItemInArray(array: any[]) {
   return array[Math.floor(Math.random() * array.length)]
 }
+
+export function hexToHsl(hex: string) {
+  hex = hex.replace('#', '')
+  if (hex.length === 3) {
+    hex = hex.split('').map((c) => c + c).join('')
+  }
+  const r = parseInt(hex.slice(0, 2), 16) / 255
+  const g = parseInt(hex.slice(2, 4), 16) / 255
+  const b = parseInt(hex.slice(4, 6), 16) / 255
+  const max = Math.max(r, g, b)
+  const min = Math.min(r, g, b)
+  let h = 0
+  let s = 0
+  const l = (max + min) / 2
+  if (max !== min) {
+    const d = max - min
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min)
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0)
+        break
+      case g:
+        h = (b - r) / d + 2
+        break
+      case b:
+        h = (r - g) / d + 4
+        break
+    }
+    h *= 60
+  }
+  return { h, s: s * 100, l: l * 100 }
+}
+
+export function hslToHex(h: number, s: number, l: number) {
+  s /= 100
+  l /= 100
+  const c = (1 - Math.abs(2 * l - 1)) * s
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1))
+  const m = l - c / 2
+  let r = 0
+  let g = 0
+  let b = 0
+  if (0 <= h && h < 60) {
+    r = c
+    g = x
+    b = 0
+  } else if (60 <= h && h < 120) {
+    r = x
+    g = c
+    b = 0
+  } else if (120 <= h && h < 180) {
+    r = 0
+    g = c
+    b = x
+  } else if (180 <= h && h < 240) {
+    r = 0
+    g = x
+    b = c
+  } else if (240 <= h && h < 300) {
+    r = x
+    g = 0
+    b = c
+  } else {
+    r = c
+    g = 0
+    b = x
+  }
+  const toHex = (v: number) => {
+    return Math.round((v + m) * 255)
+      .toString(16)
+      .padStart(2, '0')
+  }
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`
+}
+
+export async function getAverageImageColor(src: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    const img = new Image()
+    img.crossOrigin = 'Anonymous'
+    img.src = src
+    img.onload = () => {
+      const canvas = document.createElement('canvas')
+      canvas.width = img.width
+      canvas.height = img.height
+      const ctx = canvas.getContext('2d')
+      if (!ctx) {
+        resolve(null)
+        return
+      }
+      ctx.drawImage(img, 0, 0)
+      const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data
+      let r = 0
+      let g = 0
+      let b = 0
+      const total = data.length / 4
+      for (let i = 0; i < data.length; i += 4) {
+        r += data[i]
+        g += data[i + 1]
+        b += data[i + 2]
+      }
+      r = Math.round(r / total)
+      g = Math.round(g / total)
+      b = Math.round(b / total)
+      resolve(`#${r.toString(16).padStart(2, '0')}${g
+        .toString(16)
+        .padStart(2, '0')}${b.toString(16).padStart(2, '0')}`)
+    }
+    img.onerror = () => resolve(null)
+  })
+}
+
+export function createComplementaryScheme(baseHex: string) {
+  const { h, s, l } = hexToHsl(baseHex)
+  const complementHue = (h + 180) % 360
+  const accentHue = (h + 90) % 360
+  return {
+    primary: hslToHex(h, s, l),
+    secondary: hslToHex(complementHue, s, l),
+    accent: hslToHex(accentHue, s, l),
+    background: hslToHex(h, Math.max(20, s / 2), Math.min(95, l + 30))
+  }
+}


### PR DESCRIPTION
## Summary
- create color helper to generate complementary color schemes
- integrate new scheme generator in Randomize Style button
- compute colors from logo image when available
- test color utilities

## Testing
- `pnpm vitest run` *(fails: vitest not found)*