### PR TITLE
Add preset env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ docker run -d -p 8081:8080 mini-qr
 - The production image uses Nginx for optimal static file serving.
 - The `.dockerignore` file is included for smaller, faster builds.
 - Set `HIDE_CREDITS=1` to remove the maintainer credit from the footer.
+- Set `DEFAULT_PRESET` or `FRAME_PRESET` to choose the default QR code and frame presets.
+- Override `PRESETS` or `FRAME_PRESETS` with a JSON array to fully customize presets.
 
 ## Contributing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,10 @@ services:
     restart: unless-stopped
     environment:
       - VITE_HIDE_CREDITS=${HIDE_CREDITS:-false}
+      - VITE_DEFAULT_PRESET=${DEFAULT_PRESET:-}
+      - VITE_PRESETS=${PRESETS:-}
+      - VITE_FRAME_PRESET=${FRAME_PRESET:-}
+      - VITE_FRAME_PRESETS=${FRAME_PRESETS:-}
     # Uncomment the following lines to build locally instead of pulling from ghcr.io
     # build:
     #   context: .

--- a/env.d.ts
+++ b/env.d.ts
@@ -2,6 +2,10 @@
 
 interface ImportMetaEnv {
   readonly VITE_HIDE_CREDITS?: string
+  readonly VITE_DEFAULT_PRESET?: string
+  readonly VITE_PRESETS?: string
+  readonly VITE_FRAME_PRESET?: string
+  readonly VITE_FRAME_PRESETS?: string
 }
 
 interface ImportMeta {

--- a/src/components/QRCodeCreate.vue
+++ b/src/components/QRCodeCreate.vue
@@ -26,8 +26,8 @@ import {
 import { parseCSV, validateCSVData } from '@/utils/csv'
 import { generateVCardData } from '@/utils/dataEncoding'
 import { getNumericCSSValue } from '@/utils/formatting'
-import { allPresets, type Preset } from '@/utils/presets'
-import { allFramePresets, type FramePreset } from '@/utils/framePresets'
+import { allPresets, defaultPreset, type Preset } from '@/utils/presets'
+import { allFramePresets, defaultFramePreset, type FramePreset } from '@/utils/framePresets'
 import { useMediaQuery } from '@vueuse/core'
 import JSZip from 'jszip'
 import {
@@ -65,7 +65,6 @@ const { t } = useI18n()
 //#endregion
 
 //#region /* QR code style settings */
-const defaultPreset = allPresets[0]
 const data = ref(props.initialData || '')
 const debouncedData = ref(data.value)
 let dataDebounceTimer: ReturnType<typeof setTimeout>
@@ -301,7 +300,6 @@ const frameStyle = ref<FrameStyle>({
   borderRadius: '8px',
   padding: '16px'
 })
-const defaultFramePreset = allFramePresets[0]
 const selectedFramePresetKey = ref<string>(defaultFramePreset.name)
 const lastCustomLoadedFramePreset = ref<FramePreset>()
 const CUSTOM_LOADED_FRAME_PRESET_KEYS = [

--- a/src/utils/framePresets.ts
+++ b/src/utils/framePresets.ts
@@ -14,7 +14,7 @@ export interface FramePreset {
   position?: 'top' | 'bottom' | 'left' | 'right'
 }
 
-export const defaultFramePreset: FramePreset = {
+export const plainFramePreset: FramePreset = {
   name: 'Default Frame',
   style: {
     textColor: '#000000',
@@ -50,8 +50,25 @@ export const borderlessFramePreset: FramePreset = {
   }
 }
 
-export const allFramePresets: FramePreset[] = [
-  defaultFramePreset,
+export const builtInFramePresets: FramePreset[] = [
+  plainFramePreset,
   darkFramePreset,
   borderlessFramePreset
 ]
+
+function parseFramePresetsFromEnv(envVal?: string): FramePreset[] | undefined {
+  if (!envVal) return undefined
+  try {
+    return JSON.parse(envVal) as FramePreset[]
+  } catch (err) {
+    console.error('Failed to parse VITE_FRAME_PRESETS', err)
+    return undefined
+  }
+}
+
+const envFramePresets = parseFramePresetsFromEnv(import.meta.env.VITE_FRAME_PRESETS)
+export const allFramePresets: FramePreset[] = envFramePresets ?? builtInFramePresets
+
+export const defaultFramePreset: FramePreset =
+  allFramePresets.find((p) => p.name === import.meta.env.VITE_FRAME_PRESET) ??
+  allFramePresets[0]

--- a/src/utils/presets.ts
+++ b/src/utils/presets.ts
@@ -244,7 +244,7 @@ export const vueJsPreset: Preset = {
 
 // Individual presets
 
-export const defaultPreset: Preset = {
+export const lyqhtPreset: Preset = {
   ...defaultPresetOptions,
   name: 'Default (lyqht)',
   data: 'https://github.com/lyqht',
@@ -316,8 +316,8 @@ export const hackomania2025Preset = {
   style: Hackomania2025Config.style
 } as Preset
 
-export const allPresets: Preset[] = [
-  defaultPreset,
+export const builtInPresets: Preset[] = [
+  lyqhtPreset,
   plainPreset,
   ...[
     padletPreset,
@@ -336,3 +336,20 @@ export const allPresets: Preset[] = [
     hackomania2025Preset
   ].sort((a, b) => a.name.localeCompare(b.name))
 ]
+
+function parsePresetsFromEnv(envVal?: string): Preset[] | undefined {
+  if (!envVal) return undefined
+  try {
+    return JSON.parse(envVal) as Preset[]
+  } catch (err) {
+    console.error('Failed to parse VITE_PRESETS', err)
+    return undefined
+  }
+}
+
+const envPresets = parsePresetsFromEnv(import.meta.env.VITE_PRESETS)
+export const allPresets: Preset[] = envPresets ?? builtInPresets
+
+export const defaultPreset: Preset =
+  allPresets.find((p) => p.name === import.meta.env.VITE_DEFAULT_PRESET) ??
+  allPresets[0]


### PR DESCRIPTION
## Summary
- allow customizing QR code presets through environment variables
- support custom frame presets and default frame preset
- document new environment variables
- rename frame preset constant to `plainFramePreset`

## Testing
- `pnpm lint` *(fails: Invalid option '--ignore-path' - maybe dependencies missing)*
- `pnpm type-check` *(fails: vue-tsc not found)*


------
https://chatgpt.com/codex/tasks/task_b_683d2fc2969c8328a9486454864ce3c4