### PR TITLE
Fix frame preference persistence

### DIFF
--- a/src/components/QRCodeCreate.vue
+++ b/src/components/QRCodeCreate.vue
@@ -328,7 +328,6 @@ function applyFramePreset(preset: FramePreset) {
   }
   if (preset.text) frameText.value = preset.text
   if (preset.position) frameTextPosition.value = preset.position
-  showFrame.value = true
 }
 watch(
   selectedFramePresetKey,


### PR DESCRIPTION
## Summary
- keep disabled frame setting across refresh by not auto-enabling frames when applying a preset

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*
- `npm run vitest` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68561ac60c5c8328a7629fecd132b2c0