### PR TITLE
Improve .env.example base path 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ CROWDIN_PROJECT_ID="your_project_id"
 
 # Base path for deployment (e.g., /mini-qr for deploying at domain.com/mini-qr)
 # Default: /
-BASE_PATH=/
+BASE_PATH=/mini-qr
 
 VITE_HIDE_CREDITS=false
 VITE_DEFAULT_PRESET=plain


### PR DESCRIPTION
Resolves #176 

Changes the BASE_PATH in `.env.example` to match the default proxy that will be applied when `docker-compose.yml` is used