### PR TITLE
fix: SVG export shows only ~10% of QR code due to misaligned clip rect

### DIFF
--- a/src/utils/convertToImage.ts
+++ b/src/utils/convertToImage.ts
@@ -90,12 +90,27 @@ const applySvgRoundedCorners = (svgDocument: Document, options: Options, borderR
   if (options.width) svgElement.setAttribute('width', options.width.toString())
   if (options.height) svgElement.setAttribute('height', options.height.toString())
 
+  // Read the viewBox origin so the clip rect aligns with the actual content coordinates.
+  // dom-to-svg places content at the element's absolute page position, so the viewBox
+  // min-x/min-y are non-zero. Without matching x/y on the clip rect it only covers the
+  // top-left corner of the coordinate space and clips most of the QR code.
+  let vbX = 0,
+    vbY = 0
+  const viewBox = svgElement.getAttribute('viewBox')
+  if (viewBox) {
+    const [x, y] = viewBox.split(' ').map(Number)
+    vbX = x
+    vbY = y
+  }
+
   const svgNS = 'http://www.w3.org/2000/svg'
   const defs = svgDocument.createElementNS(svgNS, 'defs')
   const clipPath = svgDocument.createElementNS(svgNS, 'clipPath')
   clipPath.setAttribute('id', 'rounded-clip')
 
   const rect = svgDocument.createElementNS(svgNS, 'rect')
+  rect.setAttribute('x', vbX.toString())
+  rect.setAttribute('y', vbY.toString())
   rect.setAttribute('width', (options.width || 400).toString())
   rect.setAttribute('height', (options.height || 400).toString())
   rect.setAttribute('rx', radius.toString())

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,87 +2,89 @@ import animate from 'tailwindcss-animate'
 import typography from '@tailwindcss/typography'
 
 /** @type {import('tailwindcss').Config} */
-export const content = [
-  './pages/**/*.{ts,tsx,vue}',
-  './components/**/*.{ts,tsx,vue}',
-  './app/**/*.{ts,tsx,vue}',
-  './src/**/*.{ts,tsx,vue}'
-]
-export const darkMode = 'class'
-export const theme = {
-  container: {
-    center: true,
-    padding: '2rem',
-    screens: {
-      '2xl': '1400px'
+export default {
+  content: [
+    './pages/**/*.{ts,tsx,vue}',
+    './components/**/*.{ts,tsx,vue}',
+    './app/**/*.{ts,tsx,vue}',
+    './src/**/*.{ts,tsx,vue}'
+  ],
+  darkMode: 'class',
+  theme: {
+    container: {
+      center: true,
+      padding: '2rem',
+      screens: {
+        '2xl': '1400px'
+      }
+    },
+    extend: {
+      colors: {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))'
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))'
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))'
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))'
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))'
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))'
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))'
+        }
+      },
+      borderRadius: {
+        xl: 'calc(var(--radius) + 4px)',
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)'
+      },
+      keyframes: {
+        'accordion-down': {
+          from: { height: 0 },
+          to: { height: 'var(--radix-accordion-content-height)' }
+        },
+        'accordion-up': {
+          from: { height: 'var(--radix-accordion-content-height)' },
+          to: { height: 0 }
+        },
+        'collapsible-down': {
+          from: { height: 0 },
+          to: { height: 'var(--radix-collapsible-content-height)' }
+        },
+        'collapsible-up': {
+          from: { height: 'var(--radix-collapsible-content-height)' },
+          to: { height: 0 }
+        }
+      },
+      animation: {
+        'accordion-down': 'accordion-down 0.2s ease-out',
+        'accordion-up': 'accordion-up 0.2s ease-out',
+        'collapsible-down': 'collapsible-down 0.2s ease-in-out',
+        'collapsible-up': 'collapsible-up 0.2s ease-in-out'
+      }
     }
   },
-  extend: {
-    colors: {
-      border: 'hsl(var(--border))',
-      input: 'hsl(var(--input))',
-      ring: 'hsl(var(--ring))',
-      background: 'hsl(var(--background))',
-      foreground: 'hsl(var(--foreground))',
-      primary: {
-        DEFAULT: 'hsl(var(--primary))',
-        foreground: 'hsl(var(--primary-foreground))'
-      },
-      secondary: {
-        DEFAULT: 'hsl(var(--secondary))',
-        foreground: 'hsl(var(--secondary-foreground))'
-      },
-      destructive: {
-        DEFAULT: 'hsl(var(--destructive))',
-        foreground: 'hsl(var(--destructive-foreground))'
-      },
-      muted: {
-        DEFAULT: 'hsl(var(--muted))',
-        foreground: 'hsl(var(--muted-foreground))'
-      },
-      accent: {
-        DEFAULT: 'hsl(var(--accent))',
-        foreground: 'hsl(var(--accent-foreground))'
-      },
-      popover: {
-        DEFAULT: 'hsl(var(--popover))',
-        foreground: 'hsl(var(--popover-foreground))'
-      },
-      card: {
-        DEFAULT: 'hsl(var(--card))',
-        foreground: 'hsl(var(--card-foreground))'
-      }
-    },
-    borderRadius: {
-      xl: 'calc(var(--radius) + 4px)',
-      lg: 'var(--radius)',
-      md: 'calc(var(--radius) - 2px)',
-      sm: 'calc(var(--radius) - 4px)'
-    },
-    keyframes: {
-      'accordion-down': {
-        from: { height: 0 },
-        to: { height: 'var(--radix-accordion-content-height)' }
-      },
-      'accordion-up': {
-        from: { height: 'var(--radix-accordion-content-height)' },
-        to: { height: 0 }
-      },
-      'collapsible-down': {
-        from: { height: 0 },
-        to: { height: 'var(--radix-collapsible-content-height)' }
-      },
-      'collapsible-up': {
-        from: { height: 'var(--radix-collapsible-content-height)' },
-        to: { height: 0 }
-      }
-    },
-    animation: {
-      'accordion-down': 'accordion-down 0.2s ease-out',
-      'accordion-up': 'accordion-up 0.2s ease-out',
-      'collapsible-down': 'collapsible-down 0.2s ease-in-out',
-      'collapsible-up': 'collapsible-up 0.2s ease-in-out'
-    }
-  }
+  plugins: [animate, typography]
 }
-export const plugins = [animate, typography]


### PR DESCRIPTION
## Summary

- **Bug**: Exported SVG files show only the leftmost ~10% of the QR code — the rest is clipped off
- **Root cause**: `applySvgRoundedCorners` in `convertToImage.ts` creates a `<clipPath>` rect at `(0, 0)`, but `dom-to-svg` captures elements at their absolute page position, so the SVG `viewBox` has non-zero `min-x`/`min-y` (e.g. `183.49 -102 200 200`). The clip rect only overlaps a ~16px sliver of the 200px-wide content area.
- **Fix**: Read the `viewBox` `min-x`/`min-y` and apply them as `x`/`y` on the clip rect so it aligns with where the content actually is.

Also fixes a pre-existing issue where `prettier-plugin-tailwindcss` crashed on every format run because `tailwind.config.js` used named ESM exports (`export const content = ...`). The plugin tries to mutate those properties, but ESM named exports are read-only by spec, causing a `TypeError`. Converted to a default export to fix it.

## Reproduction

1. Generate any QR code on https://mini-qr-code-generator.vercel.app/
2. Click **Download** → **SVG**
3. Open the file — only the leftmost ~8–10% of the QR code is visible

## Changes

- `src/utils/convertToImage.ts` — read `viewBox` origin and set matching `x`/`y` on the clip rect
- `tailwind.config.js` — convert named ESM exports to a default export (fixes `prettier-plugin-tailwindcss` crash)

## Test plan

- [ ] Generate a QR code and export as SVG — full QR code should be visible
- [ ] Export with and without background — both should render correctly
- [ ] Export with a frame — frame and text should be included
- [ ] PNG/JPG exports still work correctly