### PR TITLE
Group font options by category with optgroup and expand font list

### DIFF
--- a/src/components/QRCodeCreate.vue
+++ b/src/components/QRCodeCreate.vue
@@ -38,6 +38,8 @@ import {
   defaultFramePreset,
   FONT_OPTIONS,
   loadGoogleFont,
+  type FontCategory,
+  type FontOption,
   type FramePreset,
   type FrameStyle
 } from '@/utils/framePresets'
@@ -387,6 +389,34 @@ const frameSettings = computed(() => ({
   position: frameTextPosition.value,
   style: frameStyle.value
 }))
+
+const FONT_CATEGORY_LABELS: Record<FontCategory, string> = {
+  sans: 'Sans-serif',
+  serif: 'Serif',
+  monospace: 'Monospace',
+  display: 'Display & Cursive'
+}
+
+const groupedFontOptions = computed(() => {
+  const ungrouped: FontOption[] = []
+  const groups = new Map<FontCategory, FontOption[]>()
+  for (const font of FONT_OPTIONS) {
+    if (!font.category) {
+      ungrouped.push(font)
+      continue
+    }
+    const list = groups.get(font.category) ?? []
+    list.push(font)
+    groups.set(font.category, list)
+  }
+  const orderedCategories: FontCategory[] = ['sans', 'serif', 'monospace', 'display']
+  return {
+    ungrouped,
+    groups: orderedCategories
+      .filter((c) => groups.has(c))
+      .map((c) => ({ category: c, label: FONT_CATEGORY_LABELS[c], fonts: groups.get(c)! }))
+  }
+})
 
 function onFontFamilyChange(value: string): Promise<void> {
   // value may be a label name (e.g. "Poppins" from CSV) or a full CSS value (e.g. "'Poppins', sans-serif" from UI)
@@ -1512,13 +1542,27 @@ const updateDataFromModal = (newData: string) => {
                         @change="onFontFamilyChange(($event.target as HTMLSelectElement).value)"
                       >
                         <option
-                          v-for="font in FONT_OPTIONS"
+                          v-for="font in groupedFontOptions.ungrouped"
                           :key="font.value"
                           :value="font.value"
                           :style="font.value ? { fontFamily: font.value } : {}"
                         >
                           {{ font.label }}
                         </option>
+                        <optgroup
+                          v-for="group in groupedFontOptions.groups"
+                          :key="group.category"
+                          :label="t(group.label)"
+                        >
+                          <option
+                            v-for="font in group.fonts"
+                            :key="font.value"
+                            :value="font.value"
+                            :style="{ fontFamily: font.value }"
+                          >
+                            {{ font.label }}
+                          </option>
+                        </optgroup>
                       </select>
                     </div>
                   </div>

--- a/src/utils/framePresets.ts
+++ b/src/utils/framePresets.ts
@@ -8,39 +8,120 @@ export interface FrameStyle {
   fontFamily?: string
 }
 
+export type FontCategory = 'sans' | 'serif' | 'monospace' | 'display'
+
 export interface FontOption {
   label: string
   value: string
   googleFontName?: string
+  // Omitted on the "Default" entry; everything else is categorised so the UI
+  // can render an <optgroup> per category.
+  category?: FontCategory
 }
 
 /**
- * Curated font list: system/web-safe fonts (no loading) + top Google Fonts by popularity.
- * Sources: Google Fonts popularity rankings, web typography best practices.
+ * Curated font list: web-safe fonts (no loading) + top Google Fonts.
+ *
+ * Sources:
+ *  - Google Fonts popularity rankings (sans/serif/display picks).
+ *  - Programming-font catalogues + Wikipedia "Slashed zero" article
+ *    (monospace picks — all have a slashed 0 to disambiguate from O,
+ *    requested in lyqht/mini-qr#203 for WiFi-password QR codes).
  */
 export const FONT_OPTIONS: FontOption[] = [
   { label: 'Default', value: '' },
-  // Web-safe fonts — no external loading needed
-  { label: 'Arial', value: 'Arial, sans-serif' },
-  { label: 'Georgia', value: 'Georgia, serif' },
-  { label: 'Verdana', value: 'Verdana, sans-serif' },
-  { label: 'Courier New', value: "'Courier New', monospace" },
-  { label: 'Times New Roman', value: "'Times New Roman', serif" },
-  // Google Fonts — loaded dynamically on selection
-  { label: 'Roboto', value: "'Roboto', sans-serif", googleFontName: 'Roboto' },
-  { label: 'Open Sans', value: "'Open Sans', sans-serif", googleFontName: 'Open+Sans' },
-  { label: 'Lato', value: "'Lato', sans-serif", googleFontName: 'Lato' },
-  { label: 'Montserrat', value: "'Montserrat', sans-serif", googleFontName: 'Montserrat' },
-  { label: 'Poppins', value: "'Poppins', sans-serif", googleFontName: 'Poppins' },
-  { label: 'Oswald', value: "'Oswald', sans-serif", googleFontName: 'Oswald' },
-  { label: 'Raleway', value: "'Raleway', sans-serif", googleFontName: 'Raleway' },
-  { label: 'Nunito', value: "'Nunito', sans-serif", googleFontName: 'Nunito' },
+  // Sans-serif
+  { label: 'Arial', value: 'Arial, sans-serif', category: 'sans' },
+  { label: 'Verdana', value: 'Verdana, sans-serif', category: 'sans' },
+  { label: 'Roboto', value: "'Roboto', sans-serif", googleFontName: 'Roboto', category: 'sans' },
+  { label: 'Inter', value: "'Inter', sans-serif", googleFontName: 'Inter', category: 'sans' },
+  {
+    label: 'Open Sans',
+    value: "'Open Sans', sans-serif",
+    googleFontName: 'Open+Sans',
+    category: 'sans'
+  },
+  { label: 'Lato', value: "'Lato', sans-serif", googleFontName: 'Lato', category: 'sans' },
+  {
+    label: 'Montserrat',
+    value: "'Montserrat', sans-serif",
+    googleFontName: 'Montserrat',
+    category: 'sans'
+  },
+  {
+    label: 'Poppins',
+    value: "'Poppins', sans-serif",
+    googleFontName: 'Poppins',
+    category: 'sans'
+  },
+  { label: 'Oswald', value: "'Oswald', sans-serif", googleFontName: 'Oswald', category: 'sans' },
+  {
+    label: 'Raleway',
+    value: "'Raleway', sans-serif",
+    googleFontName: 'Raleway',
+    category: 'sans'
+  },
+  { label: 'Nunito', value: "'Nunito', sans-serif", googleFontName: 'Nunito', category: 'sans' },
+  // Serif
+  { label: 'Georgia', value: 'Georgia, serif', category: 'serif' },
+  { label: 'Times New Roman', value: "'Times New Roman', serif", category: 'serif' },
   {
     label: 'Playfair Display',
     value: "'Playfair Display', serif",
-    googleFontName: 'Playfair+Display'
+    googleFontName: 'Playfair+Display',
+    category: 'serif'
   },
-  { label: 'Pacifico', value: "'Pacifico', cursive", googleFontName: 'Pacifico' }
+  {
+    label: 'Merriweather',
+    value: "'Merriweather', serif",
+    googleFontName: 'Merriweather',
+    category: 'serif'
+  },
+  // Monospace — all Google entries below have a slashed 0
+  { label: 'Courier New', value: "'Courier New', monospace", category: 'monospace' },
+  {
+    label: 'JetBrains Mono',
+    value: "'JetBrains Mono', monospace",
+    googleFontName: 'JetBrains+Mono',
+    category: 'monospace'
+  },
+  {
+    label: 'Fira Code',
+    value: "'Fira Code', monospace",
+    googleFontName: 'Fira+Code',
+    category: 'monospace'
+  },
+  {
+    label: 'Source Code Pro',
+    value: "'Source Code Pro', monospace",
+    googleFontName: 'Source+Code+Pro',
+    category: 'monospace'
+  },
+  {
+    label: 'IBM Plex Mono',
+    value: "'IBM Plex Mono', monospace",
+    googleFontName: 'IBM+Plex+Mono',
+    category: 'monospace'
+  },
+  {
+    label: 'Inconsolata',
+    value: "'Inconsolata', monospace",
+    googleFontName: 'Inconsolata',
+    category: 'monospace'
+  },
+  // Display & cursive
+  {
+    label: 'Pacifico',
+    value: "'Pacifico', cursive",
+    googleFontName: 'Pacifico',
+    category: 'display'
+  },
+  {
+    label: 'Bebas Neue',
+    value: "'Bebas Neue', sans-serif",
+    googleFontName: 'Bebas+Neue',
+    category: 'display'
+  }
 ]
 
 export function loadGoogleFont(fontName: string): Promise<void> {


### PR DESCRIPTION
## Summary

Resolves #203

The font selector in the QR code frame settings now groups fonts into categorised `<optgroup>` sections (Sans-serif, Serif, Monospace, Display & Cursive) instead of a flat list. Several new fonts have been added, including Inter, Merriweather, JetBrains Mono, Fira Code, Source Code Pro, IBM Plex Mono, Inconsolata, and Bebas Neue. The monospace additions all feature a slashed zero, making them well-suited for WiFi-password QR codes (closes #203).

## Type of change

- [ ] Bug fix (closes a reported issue)
- [x] New feature (user-visible behaviour change)
- [ ] Refactor / internal change (no user-visible behaviour change)
- [ ] Documentation
- [ ] Translation
- [ ] New preset (see [Adding new presets](../CONTRIBUTING.md#adding-new-presets))
- [ ] Other: