### PR TITLE
Fix image/frame clearing when explicitly set to undefined

### DIFF
--- a/src/lib/qr-code/core.test.ts
+++ b/src/lib/qr-code/core.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { mergeConfig } from './core'
+import { DEFAULT_CONFIG, type ResolvedQRCodeConfig } from './types'
+
+function makeCurrent(overrides: Partial<ResolvedQRCodeConfig> = {}): ResolvedQRCodeConfig {
+  return {
+    data: 'hi',
+    size: DEFAULT_CONFIG.size,
+    margin: DEFAULT_CONFIG.margin,
+    errorCorrectionLevel: DEFAULT_CONFIG.errorCorrectionLevel,
+    dots: { ...DEFAULT_CONFIG.dots },
+    cornerSquares: { ...DEFAULT_CONFIG.cornerSquares },
+    cornerDots: { ...DEFAULT_CONFIG.cornerDots },
+    background: { ...DEFAULT_CONFIG.background },
+    ...overrides
+  }
+}
+
+describe('mergeConfig', () => {
+  it('clears the image when partial explicitly sets image to undefined', () => {
+    const current = makeCurrent({
+      image: { href: 'https://example.com/logo.png', sizeRatio: 0.4 }
+    })
+
+    const merged = mergeConfig(current, { image: undefined })
+
+    expect(merged.image).toBeUndefined()
+  })
+
+  it('keeps the current image when partial omits the image key', () => {
+    const current = makeCurrent({
+      image: { href: 'https://example.com/logo.png', sizeRatio: 0.4 }
+    })
+
+    const merged = mergeConfig(current, { data: 'new data' })
+
+    expect(merged.image?.href).toBe('https://example.com/logo.png')
+  })
+
+  it('replaces the current image when partial provides a new image', () => {
+    const current = makeCurrent({
+      image: { href: 'https://old.example.com/logo.png', sizeRatio: 0.4 }
+    })
+
+    const merged = mergeConfig(current, {
+      image: { href: 'https://new.example.com/logo.png', sizeRatio: 0.5 }
+    })
+
+    expect(merged.image?.href).toBe('https://new.example.com/logo.png')
+    expect(merged.image?.sizeRatio).toBe(0.5)
+  })
+})

--- a/src/lib/qr-code/core.ts
+++ b/src/lib/qr-code/core.ts
@@ -108,7 +108,10 @@ export function createQRCode(config: QRCodeConfig): QRCodeInstance {
   }
 }
 
-function mergeConfig(current: ResolvedQRCodeConfig, partial: Partial<QRCodeConfig>): QRCodeConfig {
+export function mergeConfig(
+  current: ResolvedQRCodeConfig,
+  partial: Partial<QRCodeConfig>
+): QRCodeConfig {
   return {
     data: partial.data ?? current.data,
     size: partial.size ?? current.size,
@@ -124,7 +127,7 @@ function mergeConfig(current: ResolvedQRCodeConfig, partial: Partial<QRCodeConfi
     background: partial.background
       ? { ...current.background, ...partial.background }
       : current.background,
-    image: partial.image === null ? undefined : (partial.image ?? current.image),
-    frame: partial.frame === null ? undefined : (partial.frame ?? current.frame)
+    image: 'image' in partial ? (partial.image ?? undefined) : current.image,
+    frame: 'frame' in partial ? (partial.frame ?? undefined) : current.frame
   }
 }


### PR DESCRIPTION
Resolves #277

## Summary

Fixes a bug where setting `image` or `frame` to `undefined` in a partial config update was not correctly clearing the value, because the previous logic used `=== null` as the sentinel for "remove this field." The fix uses `'image' in partial` / `'frame' in partial` to distinguish between an explicit `undefined` (clear the field) and a missing key (keep the current value). Adds unit tests covering all three cases for `image`: explicit `undefined`, omitted key, and a new value.

## Type of change

- [x] Bug fix (closes a reported issue)

## How was this tested?

- [x] `pnpm vitest` passes
- [ ] `pnpm test:e2e` passes (or only the unrelated, pre-existing failures listed below)
- [x] `pnpm type-check` produces no new errors
- [x] `pnpm build` succeeds
- [ ] (UI changes) Verified in the dev server in light + dark mode

Pre-existing failures still present after this change: none

## Screenshots / recordings

N/A — no UI changes.

## QR rendering changes (only if you touched `src/lib/qr-code/` or `convertToImage.ts`)

- [x] Added or updated a vitest unit test (matrix / svg / dots / frame / canvas / legacy-adapter)
- [ ] Added or updated a Storybook story under `src/lib/qr-code/stories/` for the affected shape / mode
- [ ] If output bytes change, manually scanned the exported PNG with a phone QR scanner
- [ ] If output bytes change for UTF-8 / accented input, the parity test in `tests/e2e/create.spec.ts` still passes

## Anything else reviewers should know

The old `=== null` sentinel pattern is replaced entirely. Callers that previously passed `null` to clear `image` or `frame` will need to pass `undefined` instead. `mergeConfig` is also now exported so the new unit tests can import it directly.