### PR TITLE
fix(frame): include borderWidth in SVG export canvas (#284)

### DIFF
--- a/locales/ach.json
+++ b/locales/ach.json
@@ -264,6 +264,7 @@
   "Scan Another": "Scan Another",
   "Scan for more info": "Scan for more info",
   "Scan with Camera": "Scan with Camera",
+  "Select font": "Select font",
   "Select frame preset": "Select frame preset",
   "Select language": "Select language",
   "Select QR code preset": "Select QR code preset",

--- a/locales/af.json
+++ b/locales/af.json
@@ -264,6 +264,7 @@
   "Scan Another": "Skandeer 'n ander",
   "Scan for more info": "Skandeer vir meer inligting",
   "Scan with Camera": "Skandeer met kamera",
+  "Select font": "Select font",
   "Select frame preset": "Kies raamvoorsetting",
   "Select language": "Kies taal",
   "Select QR code preset": "Kies QR-kode-voorsetting",

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -264,6 +264,7 @@
   "Scan Another": "Scan Another",
   "Scan for more info": "Scan for more info",
   "Scan with Camera": "Scan with Camera",
+  "Select font": "Select font",
   "Select frame preset": "Select frame preset",
   "Select language": "Select language",
   "Select QR code preset": "Select QR code preset",

--- a/locales/bg.json
+++ b/locales/bg.json
@@ -264,6 +264,7 @@
   "Scan Another": "Сканиране на друг",
   "Scan for more info": "Сканиране за повече информация",
   "Scan with Camera": "Сканиране с камера",
+  "Select font": "Select font",
   "Select frame preset": "Избор на предварително зададена рамка",
   "Select language": "Избор на език",
   "Select QR code preset": "Избор на предварителна настройка за QR код",

--- a/locales/bn.json
+++ b/locales/bn.json
@@ -264,6 +264,7 @@
   "Scan Another": "আরেকটি স্ক্যান করুন",
   "Scan for more info": "আরও তথ্যের জন্য স্ক্যান করুন",
   "Scan with Camera": "ক্যামেরা দিয়ে স্ক্যান করুন",
+  "Select font": "Select font",
   "Select frame preset": "ফ্রেম প্রিসেট নির্বাচন করুন",
   "Select language": "ভাষা নির্বাচন করুন",
   "Select QR code preset": "কিউআর কোড প্রিসেট নির্বাচন করুন",

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -264,6 +264,7 @@
   "Scan Another": "Escaneja un altre",
   "Scan for more info": "Escaneja per a més informació",
   "Scan with Camera": "Escaneja amb la càmera",
+  "Select font": "Select font",
   "Select frame preset": "Selecciona la configuració de marc",
   "Select language": "Seleccioneu l'idioma",
   "Select QR code preset": "Selecciona la configuració predeterminada del codi QR",

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -264,6 +264,7 @@
   "Scan Another": "Skenovat další",
   "Scan for more info": "Vyhledat více informací",
   "Scan with Camera": "Skenovat pomocí fotoaparátu",
+  "Select font": "Select font",
   "Select frame preset": "Výběr předvolby snímku",
   "Select language": "Vyberte jazyk",
   "Select QR code preset": "Vyberte předvolbu QR kódu",

--- a/locales/da.json
+++ b/locales/da.json
@@ -264,6 +264,7 @@
   "Scan Another": "Skan En Anden",
   "Scan for more info": "Scan for mere info",
   "Scan with Camera": "Scan med kamera",
+  "Select font": "Select font",
   "Select frame preset": "Vælg forudindstillet ramme",
   "Select language": "Vælg sprog",
   "Select QR code preset": "Vælg forudindstillet QR-kode",

--- a/locales/de.json
+++ b/locales/de.json
@@ -264,6 +264,7 @@
   "Scan Another": "Weiteren QR-Code scannen",
   "Scan for more info": "Für weitere Informationen scannen",
   "Scan with Camera": "Mit Kamera scannen",
+  "Select font": "Select font",
   "Select frame preset": "Rahmen-Voreinstellung auswählen",
   "Select language": "Sprache auswählen",
   "Select QR code preset": "QR-Code-Voreinstellung auswählen",

--- a/locales/el.json
+++ b/locales/el.json
@@ -264,6 +264,7 @@
   "Scan Another": "Σάρωση Άλλης",
   "Scan for more info": "Σάρωση για περισσότερες πληροφορίες",
   "Scan with Camera": "Σάρωση με κάμερα",
+  "Select font": "Select font",
   "Select frame preset": "Επιλογή προεπιλογής καρέ",
   "Select language": "Επιλέξτε γλώσσα",
   "Select QR code preset": "Επιλέξτε προεπιλογή κώδικα QR",

--- a/locales/en.json
+++ b/locales/en.json
@@ -264,6 +264,7 @@
   "Scan Another": "Scan Another",
   "Scan for more info": "Scan for more info",
   "Scan with Camera": "Scan with Camera",
+  "Select font": "Select font",
   "Select frame preset": "Select frame preset",
   "Select language": "Select language",
   "Select QR code preset": "Select QR code preset",

--- a/locales/es.json
+++ b/locales/es.json
@@ -264,6 +264,7 @@
   "Scan Another": "Scan Another",
   "Scan for more info": "Scan for more info",
   "Scan with Camera": "Scan with Camera",
+  "Select font": "Select font",
   "Select frame preset": "Select frame preset",
   "Select language": "Select language",
   "Select QR code preset": "Select QR code preset",

--- a/locales/et.json
+++ b/locales/et.json
@@ -264,6 +264,7 @@
   "Scan Another": "Skaneeri teine",
   "Scan for more info": "Skaneeri lisainfo saamiseks",
   "Scan with Camera": "Kaameraga skaneerimine",
+  "Select font": "Select font",
   "Select frame preset": "Valige kaadri eelseadistus",
   "Select language": "Valige keel",
   "Select QR code preset": "Valige QR-koodi eelseadistus",

--- a/locales/fa.json
+++ b/locales/fa.json
@@ -264,6 +264,7 @@
   "Scan Another": "اسکن دیگری",
   "Scan for more info": "برای اطلاعات بیشتر اسکن کنید",
   "Scan with Camera": "اسکن با دوربین",
+  "Select font": "Select font",
   "Select frame preset": "انتخاب پیش‌تنظیم قاب",
   "Select language": "زبان را انتخاب کنید",
   "Select QR code preset": "انتخاب پیش‌تنظیم کد QR",

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -264,6 +264,7 @@
   "Scan Another": "Skannaa Toinen",
   "Scan for more info": "Lue lisätietoja",
   "Scan with Camera": "Skannaa kameralla",
+  "Select font": "Select font",
   "Select frame preset": "Valitse kehyksen esiasetus",
   "Select language": "Valitse kieli",
   "Select QR code preset": "Valitse QR-koodin esiasetus",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -264,6 +264,7 @@
   "Scan Another": "Scanner un autre",
   "Scan for more info": "Scanner pour plus d'informations",
   "Scan with Camera": "Scanner avec l'appareil photo",
+  "Select font": "Select font",
   "Select frame preset": "Sélectionner le préréglage du cadre",
   "Select language": "Sélectionner la langue",
   "Select QR code preset": "Sélectionner le préréglage du code QR",

--- a/locales/he.json
+++ b/locales/he.json
@@ -264,6 +264,7 @@
   "Scan Another": "סרוק אחר",
   "Scan for more info": "סרוק לקבלת מידע נוסף",
   "Scan with Camera": "סרוק עם המצלמה",
+  "Select font": "Select font",
   "Select frame preset": "בחר הגדרת מסגרת קבועה מראש",
   "Select language": "בחר שפה",
   "Select QR code preset": "בחר קידוד QR קבוע מראש",

--- a/locales/hi.json
+++ b/locales/hi.json
@@ -264,6 +264,7 @@
   "Scan Another": "दूसरे को स्कैन करें",
   "Scan for more info": "अधिक जानकारी के लिए स्कैन करें",
   "Scan with Camera": "कैमरे से स्कैन करें",
+  "Select font": "Select font",
   "Select frame preset": "फ़्रेम प्रीसेट चुनें",
   "Select language": "भाषा चुनें",
   "Select QR code preset": "क्यूआर कोड प्रीसेट चुनें",

--- a/locales/hr.json
+++ b/locales/hr.json
@@ -264,6 +264,7 @@
   "Scan Another": "Skeniraj drugo",
   "Scan for more info": "Skenirajte za više informacija",
   "Scan with Camera": "Skeniraj kamerom",
+  "Select font": "Select font",
   "Select frame preset": "Odabir unaprijed postavljenog okvira",
   "Select language": "Odaberite jezik",
   "Select QR code preset": "Odaberite QR kod preset",

--- a/locales/hu.json
+++ b/locales/hu.json
@@ -264,6 +264,7 @@
   "Scan Another": "Másik beolvasás",
   "Scan for more info": "További információért szkennelés",
   "Scan with Camera": "Szkennelés kamerával",
+  "Select font": "Select font",
   "Select frame preset": "Keret előbeállítás kiválasztása",
   "Select language": "Nyelv kiválasztása",
   "Select QR code preset": "QR-kód előbeállítás kiválasztása",

--- a/locales/id.json
+++ b/locales/id.json
@@ -264,6 +264,7 @@
   "Scan Another": "Memindai yang lain",
   "Scan for more info": "Pindai untuk info lebih lanjut",
   "Scan with Camera": "Memindai dengan Kamera",
+  "Select font": "Select font",
   "Select frame preset": "Memilih preset bingkai",
   "Select language": "Pilih bahasa",
   "Select QR code preset": "Memilih preset kode QR",

--- a/locales/it.json
+++ b/locales/it.json
@@ -264,6 +264,7 @@
   "Scan Another": "Scansionane un altro",
   "Scan for more info": "Scansiona per saperne di più",
   "Scan with Camera": "Scansiona con la fotocamera",
+  "Select font": "Select font",
   "Select frame preset": "Selezionare il modello della cornice",
   "Select language": "Seleziona lingua",
   "Select QR code preset": "Selezionare il modello del codice QR",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -264,6 +264,7 @@
   "Scan Another": "別のものをスキャン",
   "Scan for more info": "詳細情報をスキャン",
   "Scan with Camera": "カメラでスキャン",
+  "Select font": "Select font",
   "Select frame preset": "フレームプリセットを選択",
   "Select language": "言語を選択",
   "Select QR code preset": "QRコードのプリセットを選択",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -264,6 +264,7 @@
   "Scan Another": "다른 스캔",
   "Scan for more info": "자세한 정보 보기",
   "Scan with Camera": "카메라로 스캔",
+  "Select font": "Select font",
   "Select frame preset": "프레임 프리셋 선택",
   "Select language": "언어 선택",
   "Select QR code preset": "QR코드 사전 설정 선택",

--- a/locales/lt.json
+++ b/locales/lt.json
@@ -264,6 +264,7 @@
   "Scan Another": "Nuskaityti kitą",
   "Scan for more info": "Nuskaitykite, kad gautumėte daugiau informacijos",
   "Scan with Camera": "Nuskaitymas fotoaparatu",
+  "Select font": "Select font",
   "Select frame preset": "Pasirinkite išankstinį kadro nustatymą",
   "Select language": "Pasirinkite kalbą",
   "Select QR code preset": "Pasirinkite išankstinį QR kodo nustatymą",

--- a/locales/ms.json
+++ b/locales/ms.json
@@ -264,6 +264,7 @@
   "Scan Another": "Imbas Satu Lagi",
   "Scan for more info": "Imbas untuk maklumat lanjut",
   "Scan with Camera": "Imbas dengan Kamera",
+  "Select font": "Select font",
   "Select frame preset": "Pilih pratetap bingkai",
   "Select language": "Pilih bahasa",
   "Select QR code preset": "Pilih pratetap kod QR",

--- a/locales/my.json
+++ b/locales/my.json
@@ -264,6 +264,7 @@
   "Scan Another": "နောက်တစ်ခု စကင်န်ရန်",
   "Scan for more info": "နောက်ထပ် အချက်အလက်များအတွက် စကင်န်ရန်",
   "Scan with Camera": "ကင်မရာဖြင့် စကင်န်ဖတ်ရန်",
+  "Select font": "Select font",
   "Select frame preset": "ဘောင်ပုံစံ ရွေးချယ်ပါ",
   "Select language": "ဘာသာစကားရွေးချယ်ပါ",
   "Select QR code preset": "ကျူအာကုဒ် ပုံစံ ရွေးချယ်ပါ",

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -264,6 +264,7 @@
   "Scan Another": "Andere scannen",
   "Scan for more info": "Zoeken naar meer informatie",
   "Scan with Camera": "Scannen met Camera",
+  "Select font": "Select font",
   "Select frame preset": "Voorkeursframe kiezen",
   "Select language": "Taal selecteren",
   "Select QR code preset": "Selecteer QR code voorinstelling",

--- a/locales/no.json
+++ b/locales/no.json
@@ -264,6 +264,7 @@
   "Scan Another": "Skann en annen",
   "Scan for more info": "Søk etter mer info",
   "Scan with Camera": "Skann med kamera",
+  "Select font": "Select font",
   "Select frame preset": "Velg ramme forhåndsinnstilling",
   "Select language": "Velg språk",
   "Select QR code preset": "Select QR code preset",

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -264,6 +264,7 @@
   "Scan Another": "Zeskanuj kolejny",
   "Scan for more info": "Skanuj po więcej informacji",
   "Scan with Camera": "Skanuj z kamerą",
+  "Select font": "Select font",
   "Select frame preset": "Wybór wstępnego ustawienia ramki",
   "Select language": "Wybierz język",
   "Select QR code preset": "Wybierz wstępne ustawienie kodu QR",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -264,6 +264,7 @@
   "Scan Another": "Digitalizar outro",
   "Scan for more info": "Digitalize para obter mais informações",
   "Scan with Camera": "Digitalizar com a câmara",
+  "Select font": "Select font",
   "Select frame preset": "Selecionar predefinição de moldura",
   "Select language": "Selecione o idioma",
   "Select QR code preset": "Selecione a predefinição do código QR",

--- a/locales/ro.json
+++ b/locales/ro.json
@@ -264,6 +264,7 @@
   "Scan Another": "Scanează altul",
   "Scan for more info": "Scanare pentru mai multe informații",
   "Scan with Camera": "Scanare cu camera",
+  "Select font": "Select font",
   "Select frame preset": "Selectați presetarea cadrului",
   "Select language": "Selectați limba",
   "Select QR code preset": "Selectați presetarea codului QR",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -264,6 +264,7 @@
   "Scan Another": "Сканировать еще",
   "Scan for more info": "Сканировать для дополнительной информации",
   "Scan with Camera": "Сканировать камеру",
+  "Select font": "Select font",
   "Select frame preset": "Выберите предустановку кадра",
   "Select language": "Выберите язык",
   "Select QR code preset": "Выберите предварительную настройку QR-кода",

--- a/locales/sk.json
+++ b/locales/sk.json
@@ -264,6 +264,7 @@
   "Scan Another": "Skenovanie ďalšieho",
   "Scan for more info": "Skenovanie pre viac informácií",
   "Scan with Camera": "Skenovanie pomocou fotoaparátu",
+  "Select font": "Select font",
   "Select frame preset": "Výber predvoľby rámu",
   "Select language": "Výber jazyka",
   "Select QR code preset": "Vyberte predvoľbu QR kódu",

--- a/locales/sq.json
+++ b/locales/sq.json
@@ -264,6 +264,7 @@
   "Scan Another": "Skano një tjetër",
   "Scan for more info": "Skano për më shumë informacion",
   "Scan with Camera": "Skano me kamerë",
+  "Select font": "Select font",
   "Select frame preset": "Zgjidhni paracaktimin e kornizës",
   "Select language": "Zgjidh gjuhën",
   "Select QR code preset": "Zgjidhni paracaktimin e kodit QR",

--- a/locales/sr.json
+++ b/locales/sr.json
@@ -264,6 +264,7 @@
   "Scan Another": "Скенирај другог",
   "Scan for more info": "Скенирајте за више информација",
   "Scan with Camera": "Скенирајте камером",
+  "Select font": "Select font",
   "Select frame preset": "Изаберите предефинисани оквир",
   "Select language": "Изаберите језик",
   "Select QR code preset": "Изаберите пресет QR кода",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -264,6 +264,7 @@
   "Scan Another": "Skanna en annan",
   "Scan for more info": "Sök efter mer information",
   "Scan with Camera": "Skanna med kamera",
+  "Select font": "Select font",
   "Select frame preset": "Välj förinställd ram",
   "Select language": "Välj språk",
   "Select QR code preset": "Välj förinställd QR-kod",

--- a/locales/th.json
+++ b/locales/th.json
@@ -264,6 +264,7 @@
   "Scan Another": "สแกนอีกครั้ง",
   "Scan for more info": "สแกนเพื่อดูข้อมูลเพิ่มเติม",
   "Scan with Camera": "สแกนด้วยกล้อง",
+  "Select font": "Select font",
   "Select frame preset": "เลือกค่ากำหนดกรอบ",
   "Select language": "เลือกภาษา",
   "Select QR code preset": "เลือก QR code preset",

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -264,6 +264,7 @@
   "Scan Another": "Başka Bir Tarama",
   "Scan for more info": "Daha fazla bilgi için tarayın",
   "Scan with Camera": "Kamera ile Tarama",
+  "Select font": "Select font",
   "Select frame preset": "Çerçeve ön ayarını seçin",
   "Select language": "Dil seçin",
   "Select QR code preset": "QR kodu ön ayarını seçin",

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -264,6 +264,7 @@
   "Scan Another": "Відсканувати ще",
   "Scan for more info": "Шукати за додатковою інформацією",
   "Scan with Camera": "Сканувати камерою",
+  "Select font": "Select font",
   "Select frame preset": "Виберіть попередню установку кадру",
   "Select language": "Вибрати мову",
   "Select QR code preset": "Виберіть попередньо встановлений QR-код",

--- a/locales/vi.json
+++ b/locales/vi.json
@@ -264,6 +264,7 @@
   "Scan Another": "Quét tiếp",
   "Scan for more info": "Quét để xem thêm thông tin",
   "Scan with Camera": "Quét bằng camera",
+  "Select font": "Select font",
   "Select frame preset": "Chọn mẫu khung có sẵn",
   "Select language": "Chọn ngôn ngữ",
   "Select QR code preset": "Chọn mẫu QR code có sẵn",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -264,6 +264,7 @@
   "Scan Another": "掃描另一個",
   "Scan for more info": "掃瞄更多資訊",
   "Scan with Camera": "使用相機掃描",
+  "Select font": "Select font",
   "Select frame preset": "選擇畫格預設值",
   "Select language": "選擇語言",
   "Select QR code preset": "選擇 QR 代碼預設值",

--- a/src/lib/qr-code/frame.test.ts
+++ b/src/lib/qr-code/frame.test.ts
@@ -60,4 +60,43 @@ describe('renderFramed', () => {
     expect(svg).not.toContain('<not-a-tag>')
     expect(svg).toContain('&lt;not-a-tag&gt;')
   })
+
+  it.each(['top', 'bottom', 'left', 'right'] as const)(
+    'reserves border width on every side for textPosition=%s',
+    (position) => {
+      const { svg, width, height } = renderFramed({
+        ...baseConfig(position),
+        frame: {
+          text: 'SCAN ME',
+          textPosition: position,
+          borderWidth: 20,
+          padding: 0
+        }
+      })
+      // QR translate offset must be at least borderWidth on the QR-side axes.
+      const m = /<g transform="translate\(([0-9.]+), ([0-9.]+)\)">/.exec(svg)
+      expect(m).not.toBeNull()
+      const tx = Number(m![1])
+      const ty = Number(m![2])
+      if (position === 'top') {
+        // QR is below caption; top inset is caption + bw, left inset is bw
+        expect(tx).toBeGreaterThanOrEqual(20)
+      } else if (position === 'bottom') {
+        expect(tx).toBeGreaterThanOrEqual(20)
+        expect(ty).toBeGreaterThanOrEqual(20)
+      } else if (position === 'left') {
+        expect(ty).toBeGreaterThanOrEqual(20)
+      } else {
+        // right: QR sits on the left, caption on the right
+        expect(tx).toBeGreaterThanOrEqual(20)
+        expect(ty).toBeGreaterThanOrEqual(20)
+      }
+      // Outer canvas grew to accommodate borders on both perpendicular sides.
+      if (position === 'top' || position === 'bottom') {
+        expect(width).toBeGreaterThanOrEqual(200 + 40)
+      } else {
+        expect(height).toBeGreaterThanOrEqual(200 + 40)
+      }
+    }
+  )
 })

--- a/src/lib/qr-code/frame.ts
+++ b/src/lib/qr-code/frame.ts
@@ -1,5 +1,5 @@
-import type { FrameConfig, ResolvedQRCodeConfig } from './types'
 import { escapeAttr, escapeText, renderQrFragment, wrapAsSvg } from './render/svg'
+import type { FrameConfig, ResolvedQRCodeConfig } from './types'
 
 const DEFAULT_FRAME: Required<Omit<FrameConfig, 'text' | 'textPosition'>> = {
   textColor: '#000000',
@@ -38,6 +38,15 @@ export function renderFramed(config: ResolvedQRCodeConfig): FramedSvg {
   const textBlockWidth = Math.max(widestLine, f.fontSize)
 
   const padding = f.padding
+  /**
+   * Border sits OUTSIDE the QR + padding box — matches the CSS preview
+   * (QRCodeFrame.vue) where the border element wraps a content box that
+   * already includes the QR and padding. Without including borderWidth in
+   * the outer dimensions and offsetting the QR by borderWidth, a thick
+   * border with padding=0 would be painted in the same pixels the QR
+   * occupies, leaving only the side opposite the caption visible.
+   */
+  const bw = f.borderWidth
   let outerW: number
   let outerH: number
   let qrX: number
@@ -48,38 +57,38 @@ export function renderFramed(config: ResolvedQRCodeConfig): FramedSvg {
 
   switch (f.textPosition) {
     case 'top':
-      outerW = size + 2 * padding
-      outerH = size + textBlockHeight + 3 * padding
-      qrX = padding
-      qrY = textBlockHeight + 2 * padding
+      outerW = size + 2 * padding + 2 * bw
+      outerH = size + textBlockHeight + 3 * padding + 2 * bw
+      qrX = padding + bw
+      qrY = textBlockHeight + 2 * padding + bw
       textX = outerW / 2
-      textY = padding + f.fontSize
+      textY = padding + bw + f.fontSize
       textAnchor = 'middle'
       break
     case 'bottom':
-      outerW = size + 2 * padding
-      outerH = size + textBlockHeight + 3 * padding
-      qrX = padding
-      qrY = padding
+      outerW = size + 2 * padding + 2 * bw
+      outerH = size + textBlockHeight + 3 * padding + 2 * bw
+      qrX = padding + bw
+      qrY = padding + bw
       textX = outerW / 2
-      textY = size + 2 * padding + f.fontSize
+      textY = size + 2 * padding + bw + f.fontSize
       textAnchor = 'middle'
       break
     case 'left':
-      outerW = size + textBlockWidth + 3 * padding
-      outerH = size + 2 * padding
-      qrX = textBlockWidth + 2 * padding
-      qrY = padding
-      textX = padding + textBlockWidth / 2
+      outerW = size + textBlockWidth + 3 * padding + 2 * bw
+      outerH = size + 2 * padding + 2 * bw
+      qrX = textBlockWidth + 2 * padding + bw
+      qrY = padding + bw
+      textX = padding + bw + textBlockWidth / 2
       textY = (outerH - textBlockHeight) / 2 + f.fontSize
       textAnchor = 'middle'
       break
     case 'right':
-      outerW = size + textBlockWidth + 3 * padding
-      outerH = size + 2 * padding
-      qrX = padding
-      qrY = padding
-      textX = size + 2 * padding + textBlockWidth / 2
+      outerW = size + textBlockWidth + 3 * padding + 2 * bw
+      outerH = size + 2 * padding + 2 * bw
+      qrX = padding + bw
+      qrY = padding + bw
+      textX = size + 2 * padding + bw + textBlockWidth / 2
       textY = (outerH - textBlockHeight) / 2 + f.fontSize
       textAnchor = 'middle'
       break
@@ -125,11 +134,7 @@ export function renderFramed(config: ResolvedQRCodeConfig): FramedSvg {
   return { svg, width: outerW, height: outerH, matrixCount }
 }
 
-function liftImage(
-  fragment: string,
-  dx: number,
-  dy: number
-): { fragment: string; image: string } {
+function liftImage(fragment: string, dx: number, dy: number): { fragment: string; image: string } {
   const match = fragment.match(/<image\b[^>]*\/>/)
   if (!match) return { fragment, image: '' }
   const adjusted = match[0]


### PR DESCRIPTION
## Summary
- Fixes the frame-clipping half of #284: with `padding: 0` and a thick `borderWidth` (e.g. `20px`), exports (SVG/PNG/JPG) showed only the caption-side border because the QR was painted on top of the other three border edges.
- Root cause was in `frame.ts`: outer dimensions used `size + 2*padding` (no border) and the QR was placed at `(padding, padding)`, so the border stroke shared pixels with the QR fragment.
- Fix: add `2 * borderWidth` to `outerW`/`outerH` and inset `qrX`/`qrY` (plus the caption baseline) by `borderWidth` for all four `textPosition` values, so the border sits outside the QR-plus-padding box — matching how `QRCodeFrame.vue` renders the preview.

### Before vs after (issue's exact config, `borderWidth: 20px`, `padding: 0px`, bottom caption)
Before — top/left/right borders clipped (matches the reporter's screenshot):
SVG `viewBox="0 0 200 221.6"`, QR group at `translate(0, 0)`.

After — full frame visible on all four sides:
SVG `viewBox="0 0 240 261.6"`, QR group at `translate(20, 20)`.

### About the second item in #284 (SVG file containing PNG bytes)
I couldn't reproduce this against the current code in either invocation path (`downloadSvgElement` for single export, `getInlinedSvgString` for batch). End-to-end through the SVG button with the reporter's config, the downloaded blob has MIME type `image/svg+xml;charset=utf-8` and starts with `<svg xmlns=…>`; the config has no embedded image so no base64 PNG is inlined. If you can repro on your end I'm happy to dig further — leaving the issue open for that half until we hear back.

## Test plan
- [x] `pnpm vitest run src/lib/qr-code/frame.test.ts` — 12/12 pass, including new regression covering all four caption positions with `borderWidth: 20`, `padding: 0`
- [x] `pnpm vitest run` — full suite 216/216 pass
- [x] Manual: ran dev server, configured the exact preset from the issue, exported PNG/SVG, confirmed all four borders are visible
- [x] Manual: re-ran all four caption positions (top/bottom/left/right) with the thick-border config — every side of the frame survives the export

🤖 Generated with [Claude Code](https://claude.com/claude-code)