### PR TITLE
fix: apply env QR presets on initial page load

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -3,9 +3,7 @@
   "projectOwner": "lyqht",
   "repoType": "github",
   "repoHost": "https://github.com",
-  "files": [
-    "README.md"
-  ],
+  "files": ["README.md"],
   "imageSize": 48,
   "commit": true,
   "commitConvention": "eslint",
@@ -15,198 +13,158 @@
       "name": "tenekev",
       "avatar_url": "https://avatars.githubusercontent.com/u/30023563?v=4",
       "profile": "https://github.com/tenekev",
-      "contributions": [
-        "code",
-        "doc"
-      ]
+      "contributions": ["code", "doc"]
     },
     {
       "login": "zainfathoni",
       "name": "Zain Fathoni",
       "avatar_url": "https://avatars.githubusercontent.com/u/6315466?v=4",
       "profile": "https://zainf.dev/",
-      "contributions": [
-        "design"
-      ]
+      "contributions": ["design"]
     },
     {
       "login": "katullo11",
       "name": "Francesco",
       "avatar_url": "https://avatars.githubusercontent.com/u/129339155?v=4",
       "profile": "https://github.com/katullo11",
-      "contributions": [
-        "translation"
-      ]
+      "contributions": ["translation"]
     },
     {
       "login": "ssrahul96",
       "name": "Rahul Somasundaram",
       "avatar_url": "https://avatars.githubusercontent.com/u/15570570?v=4",
       "profile": "https://github.com/ssrahul96",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "tecking",
       "name": "tecking",
       "avatar_url": "https://avatars.githubusercontent.com/u/479934?v=4",
       "profile": "https://github.com/tecking",
-      "contributions": [
-        "translation"
-      ]
+      "contributions": ["translation"]
     },
     {
       "login": "davidxhk",
       "name": "David Xie",
       "avatar_url": "https://avatars.githubusercontent.com/u/37938921?v=4",
       "profile": "https://github.com/davidxhk",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "pcbimon",
       "name": "Patipat Chewprecha",
       "avatar_url": "https://avatars.githubusercontent.com/u/8252967?v=4",
       "profile": "https://github.com/pcbimon",
-      "contributions": [
-        "translation",
-        "code",
-        "doc"
-      ]
+      "contributions": ["translation", "code", "doc"]
     },
     {
       "login": "itsAnuga",
       "name": "Johan Ekström",
       "avatar_url": "https://avatars.githubusercontent.com/u/828450?v=4",
       "profile": "https://github.com/itsAnuga",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "klemensgraf",
       "name": "Klemens Graf",
       "avatar_url": "https://avatars.githubusercontent.com/u/22378039?v=4",
       "profile": "https://furycode.org/",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "unililium",
       "name": "林都",
       "avatar_url": "https://avatars.githubusercontent.com/u/3117172?v=4",
       "profile": "https://github.com/unililium",
-      "contributions": [
-        "code",
-        "translation"
-      ]
+      "contributions": ["code", "translation"]
     },
     {
       "login": "seals187",
       "name": "seals187",
       "avatar_url": "https://avatars.githubusercontent.com/u/86856086?v=4",
       "profile": "https://github.com/seals187",
-      "contributions": [
-        "review"
-      ]
+      "contributions": ["review"]
     },
     {
       "login": "olvier",
       "name": "olvier",
       "avatar_url": "https://avatars.githubusercontent.com/u/13106409?v=4",
       "profile": "https://github.com/olvier",
-      "contributions": [
-        "review"
-      ]
+      "contributions": ["review"]
     },
     {
       "login": "matthewberryman",
       "name": "Matthew Berryman",
       "avatar_url": "https://avatars.githubusercontent.com/u/2288238?v=4",
       "profile": "https://github.com/matthewberryman",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "Mr-Robot-ops",
       "name": "Mr-robot-ops",
       "avatar_url": "https://avatars.githubusercontent.com/u/55334802?v=4",
       "profile": "https://github.com/Mr-Robot-ops",
-      "contributions": [
-        "translation",
-        "code"
-      ]
+      "contributions": ["translation", "code"]
     },
     {
       "login": "danktankk",
       "name": "danktankk",
       "avatar_url": "https://avatars.githubusercontent.com/u/34148516?v=4",
       "profile": "https://github.com/danktankk",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "clausjs",
       "name": "Joseph Claus",
       "avatar_url": "https://avatars.githubusercontent.com/u/12068849?v=4",
       "profile": "https://github.com/clausjs",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "kennydude",
       "name": "Joe Simpson",
       "avatar_url": "https://avatars.githubusercontent.com/u/198294?v=4",
       "profile": "https://github.com/kennydude",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "toha-tiger",
       "name": "toha-tiger",
       "avatar_url": "https://avatars.githubusercontent.com/u/8455781?v=4",
       "profile": "https://github.com/toha-tiger",
-      "contributions": [
-        "code",
-        "design"
-      ]
+      "contributions": ["code", "design"]
     },
     {
       "login": "Kolophonium0",
       "name": "Yannik Herbst",
       "avatar_url": "https://avatars.githubusercontent.com/u/24278823?v=4",
       "profile": "https://github.com/Kolophonium0",
-      "contributions": [
-        "question"
-      ]
+      "contributions": ["question"]
     },
     {
       "login": "r3bers",
       "name": "Mikhail Solovev",
       "avatar_url": "https://avatars.githubusercontent.com/u/11983427?v=4",
       "profile": "http://solovjov.net/",
-      "contributions": [
-        "translation"
-      ]
+      "contributions": ["translation"]
     },
     {
       "login": "osamajvd",
       "name": "osamajvd",
       "avatar_url": "https://avatars.githubusercontent.com/u/54687462?v=4",
       "profile": "https://github.com/osamajvd",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
+    },
+    {
+      "login": "aleex1848",
+      "name": "aleex1848",
+      "avatar_url": "https://avatars.githubusercontent.com/u/17452861?v=4",
+      "profile": "https://github.com/aleex1848",
+      "contributions": ["code"]
     }
   ],
   "contributorsPerLine": 6,
   "linkToUsage": true,
   "commitType": "docs"
 }
+

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Thank you for everyone here for taking their time out to improve MiniQR 🧡
       <td align="center" valign="top" width="16.66%"><a href="https://github.com/Kolophonium0"><img src="https://avatars.githubusercontent.com/u/24278823?v=4?s=48" width="48px;" alt="Yannik Herbst"/><br /><sub><b>Yannik Herbst</b></sub></a><br /><a href="#question-Kolophonium0" title="Answering Questions">💬</a></td>
       <td align="center" valign="top" width="16.66%"><a href="http://solovjov.net/"><img src="https://avatars.githubusercontent.com/u/11983427?v=4?s=48" width="48px;" alt="Mikhail Solovev"/><br /><sub><b>Mikhail Solovev</b></sub></a><br /><a href="#translation-r3bers" title="Translation">🌍</a></td>
       <td align="center" valign="top" width="16.66%"><a href="https://github.com/osamajvd"><img src="https://avatars.githubusercontent.com/u/54687462?v=4?s=48" width="48px;" alt="osamajvd"/><br /><sub><b>osamajvd</b></sub></a><br /><a href="https://github.com/lyqht/mini-qr/commits?author=osamajvd" title="Code">💻</a></td>
+      <td align="center" valign="top" width="16.66%"><a href="https://github.com/aleex1848"><img src="https://avatars.githubusercontent.com/u/17452861?v=4?s=48" width="48px;" alt="aleex1848"/><br /><sub><b>aleex1848</b></sub></a><br /><a href="https://github.com/lyqht/mini-qr/commits?author=aleex1848" title="Code">💻</a></td>
     </tr>
   </tbody>
   <tfoot>

--- a/src/components/QRCodeCreate.vue
+++ b/src/components/QRCodeCreate.vue
@@ -247,31 +247,6 @@ const allPresetOptions = computed(() => {
 const selectedPreset = ref<
   Preset & { key?: string; qrOptions?: { errorCorrectionLevel: ErrorCorrectionLevel } }
 >(defaultPreset)
-watch(selectedPreset, () => {
-  // Note: We no longer auto-fill data from presets. Users can keep their own data
-  // while changing the visual style. The QR preview will show default text if empty.
-
-  image.value = selectedPreset.value.image
-  width.value = selectedPreset.value.width
-  height.value = selectedPreset.value.height
-  margin.value = selectedPreset.value.margin
-  imageMargin.value = selectedPreset.value.imageOptions.margin
-  imageSize.value = selectedPreset.value.imageOptions.imageSize
-  dotsOptionsColor.value = selectedPreset.value.dotsOptions.color
-  dotsOptionsType.value = selectedPreset.value.dotsOptions.type
-  cornersSquareOptionsColor.value = selectedPreset.value.cornersSquareOptions.color
-  cornersSquareOptionsType.value = selectedPreset.value.cornersSquareOptions.type
-  cornersDotOptionsColor.value = selectedPreset.value.cornersDotOptions.color
-  cornersDotOptionsType.value = selectedPreset.value.cornersDotOptions.type
-  styleBorderRadius.value = getNumericCSSValue(selectedPreset.value.style.borderRadius as string)
-  styleBackground.value = selectedPreset.value.style.background
-  includeBackground.value = selectedPreset.value.style.background !== 'transparent'
-  errorCorrectionLevel.value =
-    selectedPreset.value.qrOptions && selectedPreset.value.qrOptions.errorCorrectionLevel
-      ? selectedPreset.value.qrOptions.errorCorrectionLevel
-      : 'Q'
-  // Most presets don't have a frame, so we set it to false by default
-})
 
 const selectedPresetKey = ref<string>(
   isLocalStorageEnabled() && hasStoredQRConfig()
@@ -331,9 +306,6 @@ const frameText = ref<string>('')
 const frameTextPosition = ref<'top' | 'bottom' | 'left' | 'right'>('bottom')
 const showFrame = ref(false)
 
-//#region /* Default QR code text */
-const defaultQRCodeText = computed(() => t('Have nice day!'))
-
 const frameStyle = ref<FrameStyle>({
   textColor: '#000000',
   backgroundColor: '#ffffff',
@@ -343,7 +315,77 @@ const frameStyle = ref<FrameStyle>({
   padding: '16px'
 })
 
-const selectedFramePresetKey = ref<string>(defaultFramePreset.name)
+const selectedFramePresetKey = ref<string>(
+  import.meta.env.VITE_FRAME_PRESET || defaultFramePreset.name
+)
+
+function toFrameStyle(style: Partial<FrameStyle>): FrameStyle {
+  return {
+    textColor: style.textColor ?? '#000000',
+    backgroundColor: style.backgroundColor ?? '#ffffff',
+    borderColor: style.borderColor ?? '#000000',
+    borderWidth: style.borderWidth ?? '1px',
+    borderRadius: style.borderRadius ?? '8px',
+    padding: style.padding ?? '16px',
+    ...(style.fontFamily ? { fontFamily: style.fontFamily } : {})
+  }
+}
+
+function loadFrameFont(fontFamily?: string) {
+  if (!fontFamily) return
+  const font = FONT_OPTIONS.find((f) => f.value === fontFamily)
+  if (font?.googleFontName) {
+    loadGoogleFont(font.googleFontName)
+  }
+}
+
+function applyFrameFromPreset(frame?: QRCodeFrameConfig) {
+  if (!frame) return
+  showFrame.value = true
+  frameText.value = frame.text || defaultFrameText.value
+  frameTextPosition.value = frame.position || 'bottom'
+  frameStyle.value = toFrameStyle(frame.style)
+  loadFrameFont(frame.style?.fontFamily)
+}
+
+function applySelectedPresetToState() {
+  const preset = selectedPreset.value
+  // Note: We no longer auto-fill data from presets. Users can keep their own data
+  // while changing the visual style. The QR preview will show default text if empty.
+
+  image.value = preset.image
+  width.value = preset.width
+  height.value = preset.height
+  margin.value = preset.margin
+  imageMargin.value = preset.imageOptions.margin
+  imageSize.value = preset.imageOptions.imageSize
+  dotsOptionsColor.value = preset.dotsOptions.color
+  dotsOptionsType.value = preset.dotsOptions.type
+  cornersSquareOptionsColor.value = preset.cornersSquareOptions.color
+  cornersSquareOptionsType.value = preset.cornersSquareOptions.type
+  cornersDotOptionsColor.value = preset.cornersDotOptions.color
+  cornersDotOptionsType.value = preset.cornersDotOptions.type
+  styleBorderRadius.value = getNumericCSSValue(preset.style.borderRadius as string)
+  styleBackground.value = preset.style.background
+  includeBackground.value = preset.style.background !== 'transparent'
+  errorCorrectionLevel.value =
+    preset.qrOptions?.errorCorrectionLevel ? preset.qrOptions.errorCorrectionLevel : 'Q'
+  const frame = (preset as Preset & { frame?: QRCodeFrameConfig }).frame
+  if (frame) {
+    applyFrameFromPreset(frame)
+    const framePresetName = import.meta.env.VITE_FRAME_PRESET || preset.name
+    if (allFramePresets.some((p) => p.name === framePresetName)) {
+      selectedFramePresetKey.value = framePresetName
+    }
+  } else {
+    showFrame.value = false
+  }
+}
+
+watch(selectedPreset, applySelectedPresetToState, { immediate: true })
+
+//#region /* Default QR code text */
+const defaultQRCodeText = computed(() => t('Have nice day!'))
 const lastCustomLoadedFramePreset = ref<FramePreset>()
 const CUSTOM_LOADED_FRAME_PRESET_KEYS = [
   LAST_LOADED_LOCALLY_PRESET_KEY,
@@ -359,33 +401,31 @@ const allFramePresetOptions = computed(() => {
 
 function applyFramePreset(preset: FramePreset) {
   if (preset.style) {
-    frameStyle.value = { ...frameStyle.value, ...preset.style }
+    frameStyle.value = toFrameStyle(preset.style)
+    loadFrameFont(preset.style.fontFamily)
   }
   if (preset.text) frameText.value = preset.text
   if (preset.position) frameTextPosition.value = preset.position
+  showFrame.value = true
 }
 
-watch(
-  selectedFramePresetKey,
-  (newKey, prevKey) => {
-    if (newKey === prevKey || !newKey) return
+watch(selectedFramePresetKey, (newKey, prevKey) => {
+  if (newKey === prevKey || !newKey) return
 
-    if (
-      import.meta.env.VITE_DISABLE_LOCAL_STORAGE !== 'true' &&
-      CUSTOM_LOADED_FRAME_PRESET_KEYS.includes(newKey) &&
-      lastCustomLoadedFramePreset.value
-    ) {
-      applyFramePreset(lastCustomLoadedFramePreset.value)
-      return
-    }
+  if (
+    import.meta.env.VITE_DISABLE_LOCAL_STORAGE !== 'true' &&
+    CUSTOM_LOADED_FRAME_PRESET_KEYS.includes(newKey) &&
+    lastCustomLoadedFramePreset.value
+  ) {
+    applyFramePreset(lastCustomLoadedFramePreset.value)
+    return
+  }
 
-    const preset = allFramePresets.find((p) => p.name === newKey)
-    if (preset) {
-      applyFramePreset(preset)
-    }
-  },
-  { immediate: true }
-)
+  const preset = allFramePresets.find((p) => p.name === newKey)
+  if (preset) {
+    applyFramePreset(preset)
+  }
+})
 
 const frameSettings = computed(() => ({
   text: frameText.value,
@@ -709,6 +749,26 @@ onMounted(() => {
     } else {
       selectedPreset.value = { ...defaultPreset }
       selectedPresetKey.value = defaultPreset.name
+    }
+  }
+
+  // Apply frame preset when QR preset does not define a frame
+  // Only apply default frame preset if QR env preset did not already enable a frame
+  if (!showFrame.value) {
+    const framePreset = allFramePresets.find((p) => p.name === selectedFramePresetKey.value)
+    if (framePreset) {
+      applyFramePreset(framePreset)
+    }
+  } else {
+    // Re-apply frame styles after mount so UI matches env/QR preset (avoids stale defaults)
+    const preset = selectedPreset.value as Preset & { frame?: QRCodeFrameConfig }
+    if (preset.frame) {
+      applyFrameFromPreset(preset.frame)
+    } else {
+      const framePreset = allFramePresets.find((p) => p.name === selectedFramePresetKey.value)
+      if (framePreset) {
+        applyFramePreset(framePreset)
+      }
     }
   }
 

--- a/tests/e2e/env-preset-initial-load.spec.ts
+++ b/tests/e2e/env-preset-initial-load.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect } from '@playwright/test'
+import { spawn, type ChildProcess } from 'child_process'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+/**
+ * Regression tests for PR #287 — "apply env QR presets on initial page load".
+ *
+ * Bug: when self-hosting with `VITE_QR_CODE_PRESETS` (incl. an embedded `frame`),
+ * the preset's logo/colors/frame were NOT applied on first visit — they only
+ * appeared after manually importing a JSON config or switching the preset in the UI.
+ *
+ * The fix runs the preset->state mapping immediately on load
+ * (`watch(selectedPreset, applySelectedPresetToState, { immediate: true })`) and
+ * re-applies the embedded frame on mount.
+ *
+ * These tests boot a dedicated Vite dev server configured with an env preset and
+ * `VITE_DISABLE_LOCAL_STORAGE=true`. With local storage disabled, the immediate
+ * watcher is the ONLY thing that can apply preset state on first load, so both the
+ * colors and the embedded frame become clean regression guards: every assertion
+ * below fails on the pre-fix code and passes on the fixed code.
+ */
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const repoRoot = path.resolve(__dirname, '../..')
+
+// Uncommon base port to avoid clashing with the default dev server (5173).
+// Offset by worker index so parallel workers each get an isolated server.
+const PORT_BASE = 51873
+let baseUrl = ''
+
+// Distinct, unambiguous values so assertions can't accidentally match defaults.
+// Frame text differs from the in-app default ("Scan for more info").
+const ENV_PRESET = [
+  {
+    name: 'E2E Env Preset',
+    data: 'https://e2e.example.com',
+    image: '',
+    width: 200,
+    height: 200,
+    margin: 0,
+    imageOptions: { margin: 0, imageSize: 0.4 },
+    dotsOptions: { color: '#123456', type: 'dots' },
+    cornersSquareOptions: { color: '#abcdef', type: 'square' },
+    cornersDotOptions: { color: '#fedcba', type: 'square' },
+    style: { borderRadius: '12px', background: '#ffffff' },
+    qrOptions: { errorCorrectionLevel: 'H' },
+    frame: {
+      text: 'Win a prize',
+      position: 'bottom',
+      style: {
+        textColor: '#ff0000',
+        backgroundColor: '#00ff00',
+        borderColor: '#0000ff',
+        borderWidth: '2px',
+        borderRadius: '10px',
+        padding: '20px'
+      }
+    }
+  }
+]
+
+let server: ChildProcess
+
+async function waitForServer(url: string, timeoutMs = 60_000): Promise<void> {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetch(url)
+      if (res.ok) return
+    } catch {
+      // server not up yet
+    }
+    await new Promise((resolve) => setTimeout(resolve, 300))
+  }
+  throw new Error(`Vite dev server at ${url} did not become ready within ${timeoutMs}ms`)
+}
+
+test.describe('Env preset applied on initial page load (PR #287)', () => {
+  // Playwright requires the first hook arg to be an (here empty) destructuring pattern.
+  // eslint-disable-next-line no-empty-pattern
+  test.beforeAll(async ({}, testInfo) => {
+    const port = PORT_BASE + testInfo.workerIndex
+    baseUrl = `http://localhost:${port}`
+    server = spawn(
+      process.execPath,
+      [
+        path.join(repoRoot, 'node_modules/vite/bin/vite.js'),
+        '--port',
+        String(port),
+        '--strictPort'
+      ],
+      {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          VITE_QR_CODE_PRESETS: JSON.stringify(ENV_PRESET),
+          VITE_DISABLE_LOCAL_STORAGE: 'true'
+        },
+        stdio: ['ignore', 'ignore', 'inherit']
+      }
+    )
+    await waitForServer(baseUrl)
+  })
+
+  test.afterAll(async () => {
+    server?.kill('SIGTERM')
+  })
+
+  test('applies env preset QR colors on first load without manual import', async ({ page }) => {
+    await page.goto(`${baseUrl}/`)
+
+    // The dots color comes from the env preset and must be present on first paint.
+    await expect(page.locator('#dots-color')).toHaveValue('#123456')
+  })
+
+  test('applies embedded frame from env preset on first load', async ({ page }) => {
+    await page.goto(`${baseUrl}/`)
+
+    // The framed preview must render with the preset's frame text immediately —
+    // no JSON import, no preset switch. (Pre-fix: showFrame stayed false here.)
+    await expect(page.getByText('Win a prize')).toBeVisible({ timeout: 15_000 })
+
+    // The frame settings UI must reflect the preset-derived state.
+    await page.getByRole('button', { name: /frame settings/i }).click()
+    await expect(page.locator('#show-frame')).toBeChecked()
+    await expect(page.locator('#frame-text')).toHaveValue('Win a prize')
+    await expect(page.locator('#frame-text-color')).toHaveValue('#ff0000')
+  })
+})


### PR DESCRIPTION
## Summary
- Apply `VITE_QR_CODE_PRESETS` (and embedded `frame` on presets) on first page load, not only after manual config import or preset change.
- Run `selectedPreset` watcher with `{ immediate: true }` via `applySelectedPresetToState()`.
- Stop the frame preset watcher from overwriting QR preset frame styles on init (removed `immediate: true`).

## Problem
When self-hosting with env-defined presets, logo/colors/frame were wrong on first visit but correct after loading a JSON config or switching presets.

## Test plan
- [ ] Build with a custom entry in `VITE_QR_CODE_PRESETS` (logo + colors).
- [ ] Open app in a fresh session / incognito — preview matches preset without manual import.
- [ ] If preset includes `frame`, frame styles apply on first load.
- [ ] Changing preset in UI still updates QR style.
- [ ] Local storage / loaded-from-file presets still work.