### PR TITLE
fix: reject unsafe logo image URLs when loading QR configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ package-lock.json
 # AI-assisted planning artifacts (specs, plans, scratch notes) — local only.
 docs/superpowers/
 .planning/
+
+# Vitest browser-mode failure screenshots
+__screenshots__/

--- a/src/components/QRCodeCreate.vue
+++ b/src/components/QRCodeCreate.vue
@@ -45,7 +45,12 @@ import {
   type FramePreset,
   type FrameStyle
 } from '@/utils/framePresets'
-import { allQrCodePresets, defaultPreset, type Preset } from '@/utils/qrCodePresets'
+import {
+  allQrCodePresets,
+  defaultPreset,
+  isValidQRCodeConfig,
+  type Preset
+} from '@/utils/qrCodePresets'
 import {
   CUSTOM_LOADED_PRESET_KEYS,
   hasStoredQRConfig,
@@ -793,8 +798,15 @@ function applyQRConfigFromJsonString(
   options?: { restoreData?: boolean }
 ) {
   try {
-    const config = JSON.parse(jsonString) as QRCodeConfig
-    applyQRConfig(config, key, options)
+    const config: unknown = JSON.parse(jsonString)
+    // Same gate as the localStorage restore path (loadQRConfig) — config
+    // files are user-provided input and must not smuggle e.g. a javascript:
+    // logo URL into the image sinks.
+    if (!isValidQRCodeConfig(config)) {
+      console.error('Invalid QR code config, ignoring it')
+      return
+    }
+    applyQRConfig(config as QRCodeConfig, key, options)
   } catch {
     console.error('Failed to parse QR code config JSON')
   }

--- a/src/utils/qrCodePresets.test.ts
+++ b/src/utils/qrCodePresets.test.ts
@@ -72,4 +72,45 @@ describe('isValidQRCodeConfig', () => {
     }
     expect(isValidQRCodeConfig(withBadFrame)).toBe(false)
   })
+
+  describe('props.image (logo) validation', () => {
+    function withImage(image: unknown) {
+      return { ...validConfig, props: { ...validConfig.props, image } }
+    }
+
+    it('returns true when image is absent', () => {
+      expect(isValidQRCodeConfig(validConfig)).toBe(true)
+    })
+
+    it('returns true when image is an empty string', () => {
+      expect(isValidQRCodeConfig(withImage(''))).toBe(true)
+    })
+
+    it('returns true when image is an http(s) URL', () => {
+      expect(isValidQRCodeConfig(withImage('https://api.iconify.design/logos:vue.svg'))).toBe(true)
+      expect(isValidQRCodeConfig(withImage('http://example.com/logo.png'))).toBe(true)
+    })
+
+    it('returns true when image is a data:image URI (uploaded logo)', () => {
+      expect(isValidQRCodeConfig(withImage('data:image/png;base64,iVBORw0KGgo='))).toBe(true)
+    })
+
+    it('returns true when image is a same-origin asset path (preset placeholder)', () => {
+      // Vite asset imports resolve to paths like this at runtime.
+      expect(isValidQRCodeConfig(withImage('/assets/placeholder_image-DZ2mUx9p.png'))).toBe(true)
+      expect(isValidQRCodeConfig(withImage('./assets/placeholder_image.png'))).toBe(true)
+    })
+
+    it('returns false when image has a non-http(s), non-image scheme', () => {
+      expect(isValidQRCodeConfig(withImage('javascript:alert(1)'))).toBe(false)
+      expect(isValidQRCodeConfig(withImage('data:text/html,<script>alert(1)</script>'))).toBe(false)
+      expect(isValidQRCodeConfig(withImage('file:///etc/passwd'))).toBe(false)
+      expect(isValidQRCodeConfig(withImage('vbscript:msgbox(1)'))).toBe(false)
+    })
+
+    it('returns false when image is not a string', () => {
+      expect(isValidQRCodeConfig(withImage(42))).toBe(false)
+      expect(isValidQRCodeConfig(withImage({ href: 'https://example.com/x.png' }))).toBe(false)
+    })
+  })
 })

--- a/src/utils/qrCodePresets.ts
+++ b/src/utils/qrCodePresets.ts
@@ -356,10 +356,30 @@ export const defaultPreset: Preset = import.meta.env.VITE_DEFAULT_PRESET
     allQrCodePresets[0])
   : allQrCodePresets[0]
 
+/**
+ * Logo image URLs are looser than frame background images
+ * (isValidFrameBackgroundImage): besides http(s) and data:image, built-in
+ * presets use Vite asset paths (e.g. /assets/placeholder_image-<hash>.png),
+ * so scheme-less same-origin paths must stay loadable. Only an explicit
+ * non-http(s), non-image scheme (javascript:, file:, data:text/html, …) is
+ * rejected — those have no business in an <image href>.
+ */
+export function isSafeImageUrl(value: string): boolean {
+  if (value === '') return true
+  if (/^data:/i.test(value)) return /^data:image\//i.test(value)
+  const scheme = /^[a-z][a-z0-9+.-]*:/i.exec(value)
+  if (scheme) return /^https?:$/i.test(scheme[0])
+  return true // scheme-less: relative or root-relative same-origin path
+}
+
 export function isValidQRCodeConfig(value: unknown): boolean {
   if (!value || typeof value !== 'object') return false
   const c = value as Record<string, unknown>
   if (!c.props || typeof c.props !== 'object') return false
+  const props = c.props as Record<string, unknown>
+  if (props.image != null && (typeof props.image !== 'string' || !isSafeImageUrl(props.image))) {
+    return false
+  }
   if (!c.style || typeof c.style !== 'object') return false
   const style = c.style as Record<string, unknown>
   if (typeof style.borderRadius !== 'string') return false

--- a/tests/e2e/create.spec.ts
+++ b/tests/e2e/create.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from '@playwright/test'
 import fs from 'fs'
+import os from 'os'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import sharp from 'sharp'
@@ -71,6 +72,62 @@ test.describe('QR Code Creation and Management', () => {
       // Re-open frame settings to check the checkbox state after load
       await openFrameSettings(page)
       await expect(page.locator('#show-frame')).not.toBeChecked()
+    })
+
+    test('rejects a config file whose logo image URL has an unsafe scheme', async ({ page }) => {
+      const pageErrors: string[] = []
+      page.on('pageerror', (err) => pageErrors.push(err.message))
+      const unsafeUrlRequests: string[] = []
+      page.on('console', (msg) => {
+        if (msg.type() === 'error' && msg.text().includes('ERR_UNKNOWN_URL_SCHEME')) {
+          unsafeUrlRequests.push(msg.text())
+        }
+      })
+
+      const originalData = 'data-before-malicious-load'
+      await page.locator('#data').fill(originalData)
+      await page.waitForTimeout(600)
+
+      // Fully valid config (same shape as a saved file, applies cleanly if
+      // accepted) except for the javascript: logo URL — the whole file must
+      // be rejected, leaving current state untouched.
+      // Own temp dir: the shared tempDir is removed by afterAll, which can
+      // race this test when describe blocks run in parallel workers.
+      const ownTempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mini-qr-config-'))
+      const maliciousConfigPath = path.join(ownTempDir, 'malicious-image-config.json')
+      fs.writeFileSync(
+        maliciousConfigPath,
+        JSON.stringify({
+          props: {
+            data: 'https://evil.example',
+            image: 'javascript:alert(1)',
+            width: 200,
+            height: 200,
+            margin: 0,
+            imageOptions: { margin: 0, imageSize: 0.4 },
+            dotsOptions: { color: '#abcdef', type: 'square' },
+            cornersSquareOptions: { color: '#abcdef', type: 'square' },
+            cornersDotOptions: { color: '#abcdef', type: 'square' }
+          },
+          style: { borderRadius: '8px', background: '#ffffff' },
+          frame: null
+        })
+      )
+
+      const fileChooserPromise = page.waitForEvent('filechooser')
+      await page.locator('#load-qr-code-config-button').click()
+      const fileChooser = await fileChooserPromise
+      await fileChooser.setFiles(maliciousConfigPath)
+      await page.waitForTimeout(1000) // Allow time for file processing and reactivity
+
+      await expect(page.locator('#data')).toHaveValue(originalData)
+      await expect(page.locator('#image-url')).not.toHaveValue('javascript:alert(1)')
+      // The unsafe URL must never reach an image sink (no load attempt), and
+      // the rejection must be a clean no-op, not a crash mid-apply.
+      expect(unsafeUrlRequests).toEqual([])
+      expect(pageErrors).toEqual([])
+
+      fs.rmSync(ownTempDir, { recursive: true, force: true })
     })
 
     test('should save and load QR config with a frame via file', async ({ page }) => {


### PR DESCRIPTION
## Summary

User-supplied QR config files (loaded via the "Load config" button) were previously parsed and applied without validating the `props.image` (logo) field, allowing a malicious config file to smuggle an unsafe URL such as `javascript:alert(1)` into an image sink. This PR extends `isValidQRCodeConfig` to reject any config whose logo URL carries a non-http(s), non-image scheme, and applies that same gate to the file-load code path in `QRCodeCreate.vue`.

## Type of change

- [x] Bug fix (closes a reported issue)

## How was this tested?

- [x] `pnpm vitest` passes
- [x] `pnpm test:e2e` passes (or only the unrelated, pre-existing failures listed below)
- [x] `pnpm type-check` produces no new errors
- [x] `pnpm build` succeeds

A new `isSafeImageUrl` unit test suite in `qrCodePresets.test.ts` covers the full matrix of accepted values (empty string, `https://`, `http://`, `data:image/…`, relative/root-relative asset paths) and rejected values (`javascript:`, `data:text/html`, `file://`, `vbscript:`).

A new Playwright e2e test in `create.spec.ts` loads a fully-shaped but malicious config file (with `javascript:alert(1)` as the logo URL), asserts that the current editor state is left untouched, that the unsafe URL never reaches an image sink, and that no page errors are thrown.

Pre-existing failures still present after this change: none.

## Screenshots / recordings

No UI changes — the rejection is a silent no-op from the user's perspective (matching the existing behaviour for other invalid configs).

## Anything else reviewers should know

`isSafeImageUrl` is intentionally more permissive than `isValidFrameBackgroundImage`: built-in presets reference Vite asset paths (e.g. `/assets/placeholder_image-<hash>.png`) that are scheme-less, so only an explicit dangerous scheme triggers rejection rather than an allowlist approach. The old `__screenshots__` artefacts left in `src/utils/` by Vitest browser mode are removed and the pattern is now covered by `.gitignore`.