### PR TITLE
chore(deps): migrate from lucide-vue-next to @lucide/vue

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@floating-ui/vue": "1.1.11",
+    "@lucide/vue": "1.17.0",
     "@vercel/analytics": "2.0.1",
     "@vitejs/plugin-vue": "5.2.4",
     "@vitejs/plugin-vue-jsx": "3.1.0",
@@ -39,7 +40,6 @@
     "file-saver": "2.0.5",
     "html5-qrcode": "2.3.8",
     "jszip": "3.10.1",
-    "lucide-vue-next": "0.321.0",
     "marked": "15.0.12",
     "qr-scanner": "1.4.2",
     "qrcode-generator": "2.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@floating-ui/vue':
         specifier: 1.1.11
         version: 1.1.11(vue@3.5.34(typescript@5.9.3))
+      '@lucide/vue':
+        specifier: 1.17.0
+        version: 1.17.0(vue@3.5.34(typescript@5.9.3))
       '@vercel/analytics':
         specifier: 2.0.1
         version: 2.0.1(react@19.2.6)(vue@3.5.34(typescript@5.9.3))
@@ -44,9 +47,6 @@ importers:
       jszip:
         specifier: 3.10.1
         version: 3.10.1
-      lucide-vue-next:
-        specifier: 0.321.0
-        version: 0.321.0(vue@3.5.34(typescript@5.9.3))
       marked:
         specifier: 15.0.12
         version: 15.0.12
@@ -1215,6 +1215,11 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@lucide/vue@1.17.0':
+    resolution: {integrity: sha512-6Q1ZHgr5FbmJzKWe5BxlNdjLj2lbmuH1zwDtVzUJofX0w9UREwKgq4F4jwKqFYyyIS4Rj3FiJvDi2k6djukmmw==}
+    peerDependencies:
+      vue: '>=3.0.1'
 
   '@mdx-js/react@3.1.1':
     resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
@@ -3189,12 +3194,6 @@ packages:
     resolution: {integrity: sha512-MhWWlVnuab1RG5/zMRRcVGXZLCXrZTgfwMikgzCegsPnG62yDQo5JnqKkrK4jO5iKqDAZGItAqN5CtKBCBWRUA==}
     engines: {node: '>=16.14'}
 
-  lucide-vue-next@0.321.0:
-    resolution: {integrity: sha512-r4IXuXuFneX2tAJF9TxXY/X5J0zIblI/pBPMR5vcAtDFVAKwWHoGSvCMk3dkH2dmD/uUZfNZiLI5fa07g4pbMA==}
-    deprecated: Package deprecated. Please use @lucide/vue instead.
-    peerDependencies:
-      vue: '>=3.0.1'
-
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -4252,8 +4251,8 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-component-type-helpers@3.3.0:
-    resolution: {integrity: sha512-vwR8DDsBysI9NWXa0okPFpCcW+BUC3sPTuLBNo1faMzw4QWMFd+3/lFYFu29ZN0q+8UReXWJHEYesC9dcXYCLg==}
+  vue-component-type-helpers@3.3.3:
+    resolution: {integrity: sha512-x4nsFpy5Pe8fqPzp/5vkTPeTTDBpAx4WVtV47Ejt0+2FQrq4pRRsJs7JmYRqMFzTu/LW+pCWEjQ3YVCkPV7f9g==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -5478,6 +5477,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@lucide/vue@1.17.0(vue@3.5.34(typescript@5.9.3))':
+    dependencies:
+      vue: 3.5.34(typescript@5.9.3)
+
   '@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
       '@types/mdx': 2.0.13
@@ -5895,7 +5898,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.5.34(typescript@5.9.3)
-      vue-component-type-helpers: 3.3.0
+      vue-component-type-helpers: 3.3.3
 
   '@swc/helpers@0.5.21':
     dependencies:
@@ -7577,10 +7580,6 @@ snapshots:
 
   lru-cache@8.0.5: {}
 
-  lucide-vue-next@0.321.0(vue@3.5.34(typescript@5.9.3)):
-    dependencies:
-      vue: 3.5.34(typescript@5.9.3)
-
   lz-string@1.5.0: {}
 
   magic-string@0.30.21:
@@ -8731,7 +8730,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-component-type-helpers@3.3.0: {}
+  vue-component-type-helpers@3.3.3: {}
 
   vue-demi@0.14.10(vue@3.5.34(typescript@5.9.3)):
     dependencies:

--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -14,7 +14,7 @@ import {
   DialogTrigger,
   DialogClose
 } from '@/components/ui/dialog'
-import { X } from 'lucide-vue-next'
+import { X } from '@lucide/vue'
 
 const { t } = useI18n()
 const { hasUnseenChangelog, markAsSeen } = useChangelogNotice()

--- a/src/components/MobileMenu.vue
+++ b/src/components/MobileMenu.vue
@@ -16,7 +16,7 @@ import {
   DialogTrigger,
   DialogClose
 } from '@/components/ui/dialog'
-import { X } from 'lucide-vue-next'
+import { X } from '@lucide/vue'
 
 defineProps<{
   isDarkMode: boolean

--- a/src/components/ui/Combobox/Combobox.vue
+++ b/src/components/ui/Combobox/Combobox.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Check, ChevronsUpDown } from 'lucide-vue-next'
+import { Check, ChevronsUpDown } from '@lucide/vue'
 
 import { Button } from '@/components/ui/button'
 import {

--- a/src/components/ui/accordion/AccordionTrigger.vue
+++ b/src/components/ui/accordion/AccordionTrigger.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { cn } from '@/lib/utils'
-import { ChevronDown } from 'lucide-vue-next'
+import { ChevronDown } from '@lucide/vue'
 import { AccordionHeader, AccordionTrigger, type AccordionTriggerProps } from 'reka-ui'
 import { computed, type HTMLAttributes } from 'vue'
 

--- a/src/components/ui/command/CommandInput.vue
+++ b/src/components/ui/command/CommandInput.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { type HTMLAttributes, computed } from 'vue'
-import { Search } from 'lucide-vue-next'
+import { Search } from '@lucide/vue'
 import { ComboboxInput, type ComboboxInputProps, useForwardProps } from 'radix-vue'
 import { cn } from '@/lib/utils'
 

--- a/src/components/ui/dialog/DialogContent.vue
+++ b/src/components/ui/dialog/DialogContent.vue
@@ -9,7 +9,7 @@ import {
   DialogPortal,
   useForwardPropsEmits
 } from 'radix-vue'
-import { X } from 'lucide-vue-next'
+import { X } from '@lucide/vue'
 import { cn } from '@/lib/utils'
 
 const props = defineProps<DialogContentProps & { class?: HTMLAttributes['class'] }>()


### PR DESCRIPTION
## Summary

`lucide-vue-next@0.321.0` is [deprecated upstream](https://github.com/lyqht/mini-qr/issues/281) in favour of `@lucide/vue`. This PR migrates to the new package.

- Replaced `lucide-vue-next@0.321.0` with `@lucide/vue@1.17.0` in `package.json` and updated `pnpm-lock.yaml`.
- Updated all 6 icon imports from `'lucide-vue-next'` → `'@lucide/vue'`.

`@lucide/vue` is a drop-in replacement — the named icon exports (`X`, `Search`, `Check`, `ChevronsUpDown`, `ChevronDown`) are identical, so no component code changed beyond the import path.

### Files touched
- `package.json` / `pnpm-lock.yaml`
- `src/components/AppFooter.vue`
- `src/components/MobileMenu.vue`
- `src/components/ui/dialog/DialogContent.vue`
- `src/components/ui/command/CommandInput.vue`
- `src/components/ui/Combobox/Combobox.vue`
- `src/components/ui/accordion/AccordionTrigger.vue`

## Verification
- `pnpm build` ✅ succeeds
- `pnpm lint` ✅ 0 errors (only pre-existing warnings)
- `pnpm type-check` ✅ no new errors (the remaining errors are pre-existing in `download.test.ts` / `useQRCodeStorage.ts` and unrelated to this change)

Closes #281

https://claude.ai/code/session_011tEk7QPzxP7fT2JakawqAK

---
_Generated by [Claude Code](https://claude.ai/code/session_011tEk7QPzxP7fT2JakawqAK)_