### PR TITLE
Round dots cut by the logo margin, and add a "1 dot" image-margin button

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1,4 +1,5 @@
 {
+  "1 dot": "1 dot",
   "ach": "Acholi",
   "af": "Afrikaans",
   "ar": "Arabic",
@@ -285,6 +286,7 @@
   "Select QR code preset": "Select QR code preset",
   "Send Email": "Send Email",
   "Send SMS": "Send SMS",
+  "Set image margin to the size of one dot": "Set image margin to the size of one dot",
   "Settings to customize your QR code": "Settings to customize your QR code",
   "Show update notice": "Show update notice",
   "Showing only the fields you use. Customize to show more.": "Showing only the fields you use. Customize to show more.",

--- a/src/components/QRCodeCreate.vue
+++ b/src/components/QRCodeCreate.vue
@@ -250,6 +250,32 @@ const margin = ref()
 const imageMargin = ref()
 const imageSize = ref<number | undefined>()
 
+// Pixel size of a single QR module ("dot") in the exported image. Mirrors the
+// renderer: size = min(width, height), moduleSize = size / (count + 2*margin),
+// where `margin` is measured in modules. Returns null when it can't be derived
+// (no data yet, missing size, or an over-long payload that fails to encode).
+const oneDotSizePx = computed<number | null>(() => {
+  const size = Math.min(Number(width.value) || 0, Number(height.value) || 0)
+  if (!size || !Number.isFinite(size)) return null
+  try {
+    const { count } = buildMatrix(previewData.value, errorCorrectionLevel.value)
+    const totalModules = count + 2 * (Number(margin.value) || 0)
+    if (totalModules <= 0) return null
+    return size / totalModules
+  } catch {
+    return null
+  }
+})
+
+// Set the image margin to exactly one dot. Combined with neighbour-aware dot
+// shapes, this gives the logo a clean one-module gap whose bordering dots round
+// into the cleared space instead of being sharply cut.
+function setImageMarginToDotSize() {
+  const dot = oneDotSizePx.value
+  if (dot == null) return
+  imageMargin.value = Math.round(dot * 100) / 100
+}
+
 watch(
   () => props.initialData,
   (newValue) => {
@@ -2582,13 +2608,25 @@ const updateDataFromModal = (newData: string) => {
                   <label for="image-margin">
                     {{ t('Image margin (px)') }}
                   </label>
-                  <input
-                    class="text-input"
-                    id="image-margin"
-                    type="number"
-                    placeholder="0"
-                    v-model="imageMargin"
-                  />
+                  <div class="flex flex-row items-stretch gap-1">
+                    <input
+                      class="text-input"
+                      id="image-margin"
+                      type="number"
+                      placeholder="0"
+                      v-model="imageMargin"
+                    />
+                    <button
+                      type="button"
+                      class="secondary-button shrink-0 whitespace-nowrap px-2 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+                      :disabled="oneDotSizePx == null"
+                      :title="t('Set image margin to the size of one dot')"
+                      :aria-label="t('Set image margin to the size of one dot')"
+                      @click="setImageMarginToDotSize"
+                    >
+                      {{ t('1 dot') }}
+                    </button>
+                  </div>
                 </div>
                 <div class="w-full sm:w-1/3" v-show="isFieldVisible('imageSize')">
                   <label for="image-size">

--- a/src/lib/qr-code/render/dots.test.ts
+++ b/src/lib/qr-code/render/dots.test.ts
@@ -56,4 +56,47 @@ describe('buildDotsPath', () => {
     expect(hidden.length).toBe(0)
     expect(full.length).toBeGreaterThan(0)
   })
+
+  // A logo with a margin clears central cells. Neighbour-aware shapes must treat
+  // those cleared cells as empty so dots bordering the logo round the corner
+  // facing it instead of being sharply cut along the margin.
+  describe('logo-cleared cells round bordering dots (regression)', () => {
+    // 15x15 matrix (large enough for a centre outside the 7x7 finder regions).
+    // Exactly one body dot renders: (7,6). Its only filled neighbour is (6,6),
+    // which sits inside the top-left finder region, so it is never drawn as its
+    // own dot but still counts as a present neighbour for corner rounding. That
+    // lets us measure the surviving dot's rounding in isolation, mirroring a dot
+    // bordering the logo-cleared region.
+    const count = 15
+    const makeMatrix = () =>
+      Array.from({ length: count }, () => Array.from({ length: count }, () => false))
+    const matrix = makeMatrix()
+    matrix[7][6] = true
+    matrix[6][6] = true
+    const base = { matrix, count, moduleSize: 10, offset: 0 } as const
+    const arcs = (d: string) => (d.match(/a/g) ?? []).length
+
+    it('extra-rounded: a cleared neighbour rounds the dot facing it', () => {
+      // (6,6) present -> top edge stays flat: only the 2 bottom corners round.
+      const noHide = buildDotsPath({ ...base, shape: 'extra-rounded' })
+      // Clearing (6,6) (as a logo margin would) -> dot is now exposed on all
+      // sides: all 4 corners round, just like the hand-fixed sample.
+      const withHide = buildDotsPath({
+        ...base,
+        shape: 'extra-rounded',
+        hideCell: (r, c) => r === 6 && c === 6
+      })
+      expect(arcs(noHide)).toBe(2)
+      expect(arcs(withHide)).toBe(4)
+    })
+
+    it('square: unaffected by cleared neighbours (no rounding by design)', () => {
+      const withHide = buildDotsPath({
+        ...base,
+        shape: 'square',
+        hideCell: (r, c) => r === 6 && c === 6
+      })
+      expect(arcs(withHide)).toBe(0)
+    })
+  })
 })

--- a/src/lib/qr-code/render/dots.ts
+++ b/src/lib/qr-code/render/dots.ts
@@ -16,15 +16,21 @@ export interface DotsRenderArgs {
  */
 export function buildDotsPath(args: DotsRenderArgs): string {
   const { matrix, count, moduleSize, offset, shape, hideCell } = args
+  // Mask out cells cleared for the centre logo. Neighbour-aware shapes round a
+  // corner only when the adjacent cells are empty, so the cleared cells must
+  // read as empty here too — otherwise dots bordering the logo keep a sharp
+  // edge along the margin instead of rounding into the cleared space.
+  const cells = hideCell
+    ? matrix.map((row, r) => row.map((on, c) => on && !hideCell(r, c)))
+    : matrix
   const parts: string[] = []
   for (let r = 0; r < count; r++) {
     for (let c = 0; c < count; c++) {
-      if (!matrix[r][c]) continue
+      if (!cells[r][c]) continue
       if (isFinderRegion(r, c, count)) continue
-      if (hideCell && hideCell(r, c)) continue
       const x = offset + c * moduleSize
       const y = offset + r * moduleSize
-      parts.push(cellPath(shape, x, y, moduleSize, r, c, matrix, count))
+      parts.push(cellPath(shape, x, y, moduleSize, r, c, cells, count))
     }
   }
   return parts.join(' ')


### PR DESCRIPTION
## Summary

When a centre logo has a margin, neighbour-aware dot shapes (`extra-rounded`,
`classy`, `classy-rounded`) left a sharp staircase edge along the cleared
area, because the logo-cleared cells were skipped from output but still read
as *filled* by the corner-rounding logic. This rounds those bordering dots
into the cleared space. It also adds a "1 dot" button next to the Image margin
input that fills it with the exact pixel size of one module, making a clean
one-dot gap around the logo trivial to set.

Closes #<!-- issue number — see note below -->

## Type of change

- [ ] Bug fix (closes a reported issue)
- [x] New feature (user-visible behaviour change)
- [ ] Refactor / internal change (no user-visible behaviour change)
- [ ] Documentation
- [ ] Translation
- [ ] New preset (see [Adding new presets](../CONTRIBUTING.md#adding-new-presets))
- [ ] Other:

## How was this tested?

- [x] `pnpm vitest` passes — the **node** project passes (all unit tests incl.
      the new `dots` regression test). The **browser** project could not launch
      in my environment (no headless browser); please confirm on your machine.
- [ ] `pnpm test:e2e` passes — not run locally.
- [x] `pnpm type-check` produces no new errors (verified by diffing against
      `main`; only the pre-existing errors below remain).
- [ ] `pnpm build` succeeds — not run locally.
- [ ] (UI changes) Verified in the dev server in light + dark mode — ran the
      dev server; please confirm dark mode.

Pre-existing failures still present after this change (all on `main`,
unrelated to this PR):

- `pnpm type-check`: `src/utils/download.test.ts` (2× TS2322, mock types),
  `src/utils/useQRCodeStorage.ts:57` (TS2322),
  `src/components/QRCodeCreate.vue` (TS2345 on an i18n key arg, TS2322 on
  CSV parsing result).

## Screenshots / recordings

<!-- Before: dots sharply cut along the logo margin. After: bordering dots
     round into the cleared space. (Drag-and-drop before/after here.) -->

## QR rendering changes (only if you touched `src/lib/qr-code/` or `convertToImage.ts`)

- [ ] Added or updated a Storybook story under `src/lib/qr-code/stories/` for
      the affected shape / mode — **not added** (see note below).
- [x] Added or updated a vitest unit test — `src/lib/qr-code/render/dots.test.ts`
      gains a regression test that isolates a single dot bordering a cleared
      cell and asserts it gains corner rounding; plus a guard that `square`
      is unaffected.
- [ ] If output bytes change, manually scanned the exported PNG with a phone —
      please scan once (see note).
- [ ] If output bytes change for UTF-8 / accented input — N/A (this change is
      independent of input encoding).

## Anything else reviewers should know

- **Scope of the visual change is narrow.** With no logo (or
  `hideBackgroundDots: false`), `cells === matrix`, so output is byte-for-byte
  identical. Output only changes when a logo with background-dot clearing is
  combined with a neighbour-aware dot shape — and even then only the corners of
  dots adjacent to the already-cleared logo zone change. The dots themselves
  stay in place, so scannability should be unaffected; a quick phone scan is
  still worth doing.
- **No Storybook story added.** The existing `dots.stories.ts` doesn't cover
  the logo-clearing interaction. Happy to add a story showing logo + margin +
  rounded dots if you'd like it for visual regression.
- **Two commits, two concerns** (`fix(dots): …` and `feat(create): …`). I can
  split into two PRs if you prefer to review/merge them separately.
- **Issue assignment:** CONTRIBUTING.md asks contributors to be assigned to an
  issue first. If there isn't one yet, I'll open issues for the rounding bug
  and the margin-button feature and link them here.
